### PR TITLE
Added "metaDir" for holey-style bags and API call to view bag manifests

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -12,3 +12,4 @@ queuePassword = datavault
 activeDir = /Users
 archiveDir = /tmp/datavault/archive
 tempDir = /tmp/datavault/temp
+metaDir = /tmp/datavault/meta

--- a/datavault-broker/src/main/java/org/datavault/broker/controllers/VaultsController.java
+++ b/datavault-broker/src/main/java/org/datavault/broker/controllers/VaultsController.java
@@ -2,12 +2,15 @@ package org.datavault.broker.controllers;
 
 import java.util.List;
 import java.util.HashMap;
+import java.io.IOException;
 
 import org.datavault.common.model.Vault;
 import org.datavault.common.model.Deposit;
+import org.datavault.common.model.FileFixity;
 import org.datavault.common.job.Job;
 import org.datavault.broker.services.VaultsService;
 import org.datavault.broker.services.DepositsService;
+import org.datavault.broker.services.MetadataService;
 import org.datavault.queue.Sender;
 
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,6 +32,7 @@ public class VaultsController {
     
     private VaultsService vaultsService;
     private DepositsService depositsService;
+    private MetadataService metadataService;
     private Sender sender;
 
     public void setVaultsService(VaultsService vaultsService) {
@@ -37,6 +41,10 @@ public class VaultsController {
     
     public void setDepositsService(DepositsService depositsService) {
         this.depositsService = depositsService;
+    }
+    
+    public void setMetadataService(MetadataService metadataService) {
+        this.metadataService = metadataService;
     }
 
     public void setSender(Sender sender) {
@@ -99,6 +107,14 @@ public class VaultsController {
                               @PathVariable("depositid") String depositID) {
         Deposit deposit = depositsService.getDeposit(depositID);
         return deposit;
+    }
+    
+    @RequestMapping(value = "/vaults/{vaultid}/deposits/{depositid}/manifest", method = RequestMethod.GET)
+    public List<FileFixity> getDepositManifest(@PathVariable("vaultid") String vaultID,
+                                      @PathVariable("depositid") String depositID) throws IOException {
+        Deposit deposit = depositsService.getDeposit(depositID);
+        List<FileFixity> manifest = metadataService.getManifest(deposit.getBagId());
+        return manifest;
     }
     
     @RequestMapping(value = "/vaults/{vaultid}/deposits/{depositid}/status", method = RequestMethod.GET)

--- a/datavault-broker/src/main/java/org/datavault/broker/services/MetadataService.java
+++ b/datavault-broker/src/main/java/org/datavault/broker/services/MetadataService.java
@@ -1,0 +1,58 @@
+package org.datavault.broker.services;
+
+import java.io.IOException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.List;
+import java.util.ArrayList;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import gov.loc.repository.bagit.BagFactory;
+import gov.loc.repository.bagit.Bag;
+import gov.loc.repository.bagit.Bag.BagPartFactory;
+import gov.loc.repository.bagit.Manifest;
+import gov.loc.repository.bagit.ManifestReader;
+
+import org.datavault.common.model.FileFixity;
+
+public class MetadataService {
+
+    private String metaDir;
+    
+    public void setMetaDir(String metaDir) {
+        this.metaDir = metaDir;
+    }
+    
+    public ArrayList<FileFixity> getManifest(String bagId) throws IOException {
+        
+        Path metaBagPath = Paths.get(metaDir, bagId);
+        BagFactory factory = new BagFactory();
+        Bag bag = factory.createBag(metaBagPath.toFile());
+        bag.loadFromFiles();
+        
+        BagPartFactory partFactory = factory.getBagPartFactory();
+        
+        List<Manifest> manifests = bag.getPayloadManifests();
+        ArrayList<FileFixity> files = new ArrayList<>();
+        
+        for (Manifest manifest : manifests) {
+            
+            Path manifestPath = metaBagPath.resolve(manifest.getFilepath());
+            File manifestFile = manifestPath.toFile();
+            FileInputStream stream = new FileInputStream(manifestFile);
+            
+            // TODO: Can we specify this as StandardCharsets.UTF_8 ?
+            ManifestReader reader = partFactory.createManifestReader(stream, "utf-8");
+            
+            while (reader.hasNext()) {
+                ManifestReader.FilenameFixity file = reader.next();
+                files.add(new FileFixity(file.getFilename(), file.getFixityValue()));
+            }
+            reader.close();
+        }
+        
+        return files;
+    }
+}
+

--- a/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
@@ -57,6 +57,7 @@
     <bean id="vaultsController" class="org.datavault.broker.controllers.VaultsController">
         <property name="vaultsService" ref="vaultsService" />
         <property name="depositsService" ref="depositsService" />
+        <property name="metadataService" ref="metadataService" />
         <property name="sender" ref="sender" />
     </bean>
 
@@ -72,6 +73,10 @@
     
     <bean id="depositsService" class="org.datavault.broker.services.DepositsService">
         <property name="depositDAO" ref="depositDAO" />
+    </bean>
+    
+    <bean id="metadataService" class="org.datavault.broker.services.MetadataService">
+        <property name="metaDir" value="${metaDir}"/>
     </bean>
 
     <bean id="sender" class="org.datavault.queue.Sender">

--- a/datavault-common/src/main/java/org/datavault/common/job/Context.java
+++ b/datavault-common/src/main/java/org/datavault/common/job/Context.java
@@ -7,12 +7,14 @@ public class Context {
     private String archiveDir;
     private String tempDir;
     private String activeDir;
+    private String metaDir;
     
     public Context() {};
-    public Context(String archiveDir, String tempDir, String activeDir) {
+    public Context(String archiveDir, String tempDir, String activeDir, String metaDir) {
         this.archiveDir = archiveDir;
         this.tempDir = tempDir;
         this.activeDir = activeDir;
+        this.metaDir = metaDir;
     }
 
     public String getArchiveDir() {
@@ -37,5 +39,13 @@ public class Context {
 
     public void setActiveDir(String activeDir) {
         this.activeDir = activeDir;
+    }
+
+    public String getMetaDir() {
+        return metaDir;
+    }
+
+    public void setMetaDir(String metaDir) {
+        this.metaDir = metaDir;
     }
 }

--- a/datavault-common/src/main/java/org/datavault/common/model/FileFixity.java
+++ b/datavault-common/src/main/java/org/datavault/common/model/FileFixity.java
@@ -1,0 +1,29 @@
+package org.datavault.common.model;
+
+public class FileFixity {
+
+    private String file;
+    private String fixity;
+    
+    public FileFixity() {}
+    public FileFixity(String file, String Fixity) {
+        this.file = file;
+        this.fixity = Fixity;
+    }
+    
+    public String getFile() {
+        return file;
+    }
+
+    public void setFile(String file) {
+        this.file = file;
+    }
+
+    public String getFixity() {
+        return fixity;
+    }
+
+    public void setFixity(String Fixity) {
+        this.fixity = Fixity;
+    }
+}

--- a/datavault-worker/src/main/java/org/datavault/worker/operations/Packager.java
+++ b/datavault-worker/src/main/java/org/datavault/worker/operations/Packager.java
@@ -1,6 +1,11 @@
 package org.datavault.worker.operations;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.commons.io.FileUtils;
 import gov.loc.repository.bagit.*;
 
 public class Packager {
@@ -18,7 +23,46 @@ public class Packager {
         } finally {
             bag.close();
         }
+        
+        return result;
+    }
+    
+    // Extract the top-level metadata files from a bag and copy to a new directory.
+    public static boolean extractMetaFiles(File bagDir, File metaDir) {
+        
+        // TODO: could we use the built-in "holey" bag methods instead?
+        
+        boolean result;
+        Path bagPath = bagDir.toPath();
+        
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(bagPath)) {
+            for (Path entry : stream) {
                 
+                /*
+                Expected:
+                - data (dir)
+                - bag-info.txt
+                - bagit.txt
+                - manifest-md5.txt
+                - tagmanifest-md5.txt
+                */
+                
+                String entryFileName = entry.getFileName().toString();
+                
+                // Copy any regular text files at the top level (but not directories)
+                if (!Files.isDirectory(entry) && entryFileName.endsWith(".txt")) {
+                    FileUtils.copyFileToDirectory(entry.toFile(), metaDir);
+                }
+            }
+            
+            // All files copied
+            result = true;
+            
+        } catch (IOException e) {
+            System.out.println(e.toString());
+            result = false;
+        }
+        
         return result;
     }
 }

--- a/datavault-worker/src/main/java/org/datavault/worker/queue/Receiver.java
+++ b/datavault-worker/src/main/java/org/datavault/worker/queue/Receiver.java
@@ -20,6 +20,7 @@ public class Receiver {
     private String archiveDir;
     private String tempDir;
     private String activeDir;
+    private String metaDir;
 
     public void setQueueServer(String queueServer) {
         this.queueServer = queueServer;
@@ -47,6 +48,10 @@ public class Receiver {
     
     public void setActiveDir(String activeDir) {
         this.activeDir = activeDir;
+    }
+    
+    public void setMetaDir(String metaDir) {
+        this.metaDir = metaDir;
     }
 
     public void receive() throws IOException, InterruptedException, TimeoutException {
@@ -79,7 +84,7 @@ public class Receiver {
                 Class<?> clazz = Class.forName(commonjob.getJobClass());
                 Job concreteJob = (Job)(mapper.readValue(message, clazz));
                 
-                Context context = new Context(archiveDir, tempDir, activeDir);
+                Context context = new Context(archiveDir, tempDir, activeDir, metaDir);
                 concreteJob.performAction(context);
                 
             } catch (Exception e) {

--- a/datavault-worker/src/main/resources/config/config.xml
+++ b/datavault-worker/src/main/resources/config/config.xml
@@ -12,6 +12,7 @@
         <property name="archiveDir" value="${archiveDir}"/>
         <property name="tempDir" value="${tempDir}"/>
         <property name="activeDir" value="${activeDir}"/>
+        <property name="metaDir" value="${metaDir}"/>
     </bean>
 
 </beans>


### PR DESCRIPTION
Added a new directory to the config where "holey-style" bags are stored (e.g. bags with no payload data and only bag metadata files). These metadata files can be used to get information about bag contents without having to retrieve the actual archived bags (which may be tarred/compressed/offline).

A new "metaDir" property has been added to build.properties to specify the path where metadata-only bags are kept.
A new API call has been added to the broker to retrieve the bag manifest for a given deposit.