### PR TITLE
Simple withdraw implementation (tar file)

### DIFF
--- a/datavault-broker/src/main/java/org/datavault/broker/controllers/VaultsController.java
+++ b/datavault-broker/src/main/java/org/datavault/broker/controllers/VaultsController.java
@@ -157,8 +157,8 @@ public class VaultsController {
             
             Job withdrawJob = new Job("org.datavault.worker.jobs.Withdraw", withdrawProperties);
             ObjectMapper mapper = new ObjectMapper();
-            String jsonDeposit = mapper.writeValueAsString(withdrawJob);
-            sender.send(jsonDeposit);
+            String jsonWithdraw = mapper.writeValueAsString(withdrawJob);
+            sender.send(jsonWithdraw);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/datavault-worker/src/main/java/org/datavault/worker/jobs/Withdraw.java
+++ b/datavault-worker/src/main/java/org/datavault/worker/jobs/Withdraw.java
@@ -1,8 +1,13 @@
 package org.datavault.worker.jobs;
 
 import java.util.Map;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.datavault.common.job.Context;
 import org.datavault.common.job.Job;
+import org.apache.commons.io.FileUtils;
 
 public class Withdraw extends Job {
     
@@ -17,5 +22,30 @@ public class Withdraw extends Job {
         
         System.out.println("\tbagID: " + bagID);
         System.out.println("\twithdrawalPath: " + withdrawalPath);
+        
+        try {
+            Path basePath = Paths.get(context.getActiveDir());
+            Path withdrawPath = basePath.resolve(withdrawalPath);
+            File withdrawDir = withdrawPath.toFile();
+
+            if (!withdrawDir.exists() || !withdrawDir.isDirectory()) {
+                // Target path must exist and be a directory
+                System.out.println("\tTarget directory not found!");
+            }
+
+            // Find the archived data
+            // TODO: a filesystem driver should transform a bagID to an actual path
+            String tarFileName = bagID + ".tar";
+            Path archivePath = Paths.get(context.getArchiveDir()).resolve(tarFileName);
+            File archiveFile = archivePath.toFile();
+
+            // Copy the tar file to the withdrawal area
+            System.out.println("\tCopying tar file from archive ...");
+            File withdrawFile = withdrawPath.resolve(tarFileName).toFile();
+            FileUtils.copyFile(archiveFile, withdrawFile);
+            
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }


### PR DESCRIPTION
Withdraw archived file job for testing. This job simply copies an archived tar file to a specified path.

The withdrawal path is obtained from the job properties object sent via the message queue.
Note that this path is relative to the archive base.

Example post (note that the path shouldn't start with a leading '/' - more validation is needed):

POST http://localhost:8080/datavault-broker/vaults/06b83813-21a5-48a9-9092-348759337b48/deposits/c33c1c69-5d46-498c-8cfe-a01786226792/withdraw
{
  "withdrawalPath": "datavault/withdraw"
}