### PR TITLE
Added broker event handler (MQ receiver)

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -6,6 +6,7 @@ dbPassword = datavault
 
 queueServer = localhost
 queueName = datavault
+eventQueueName = datavault-event
 queueUser = datavault
 queuePassword = datavault
 

--- a/datavault-broker/pom.xml
+++ b/datavault-broker/pom.xml
@@ -64,6 +64,11 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>org.springframework.amqp</groupId>
+            <artifactId>spring-rabbit</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/datavault-broker/src/main/java/org/datavault/broker/controllers/VaultsController.java
+++ b/datavault-broker/src/main/java/org/datavault/broker/controllers/VaultsController.java
@@ -102,6 +102,7 @@ public class VaultsController {
         // Ask the worker to process the deposit
         try {
             HashMap<String, String> depositProperties = new HashMap<>();
+            depositProperties.put("depositId", deposit.getID());
             depositProperties.put("bagId", deposit.getBagId());
             depositProperties.put("filePath", path.toString()); // The absolute path
             

--- a/datavault-broker/src/main/java/org/datavault/broker/services/VaultsService.java
+++ b/datavault-broker/src/main/java/org/datavault/broker/services/VaultsService.java
@@ -20,6 +20,10 @@ public class VaultsService {
         vaultDAO.save(vault);
     }
     
+    public void updateVault(Vault vault) {
+        vaultDAO.update(vault);
+    }
+    
     public Vault getVault(String vaultID) {
         return vaultDAO.findById(vaultID);
     }

--- a/datavault-broker/src/main/java/org/datavault/queue/EventListener.java
+++ b/datavault-broker/src/main/java/org/datavault/queue/EventListener.java
@@ -1,0 +1,8 @@
+package org.datavault.queue;
+
+public class EventListener {
+    
+    public void listen(String message) {
+        System.out.println(message);
+    }
+}

--- a/datavault-broker/src/main/java/org/datavault/queue/EventListener.java
+++ b/datavault-broker/src/main/java/org/datavault/queue/EventListener.java
@@ -1,8 +1,12 @@
 package org.datavault.queue;
 
-public class EventListener {
-    
-    public void listen(String message) {
-        System.out.println(message);
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageListener;
+
+public class EventListener implements MessageListener {
+
+    @Override
+    public void onMessage(Message msg) {
+        System.out.println("[x] Received '" + new String(msg.getBody()) + "'");
     }
 }

--- a/datavault-broker/src/main/java/org/datavault/queue/EventListener.java
+++ b/datavault-broker/src/main/java/org/datavault/queue/EventListener.java
@@ -1,12 +1,67 @@
 package org.datavault.queue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.datavault.broker.services.DepositsService;
+import org.datavault.broker.services.VaultsService;
+import org.datavault.common.event.Event;
+import org.datavault.common.event.deposit.*;
+import org.datavault.common.model.Deposit;
+import org.datavault.common.model.Vault;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageListener;
 
 public class EventListener implements MessageListener {
 
+    private VaultsService vaultsService;
+    private DepositsService depositsService;
+    
+    public void setVaultsService(VaultsService vaultsService) {
+        this.vaultsService = vaultsService;
+    }
+    
+    public void setDepositsService(DepositsService depositsService) {
+        this.depositsService = depositsService;
+    }
+    
     @Override
     public void onMessage(Message msg) {
-        System.out.println("[x] Received '" + new String(msg.getBody()) + "'");
+        
+        String messageBody = new String(msg.getBody());
+        System.out.println("[x] Received '" + messageBody + "'");
+        
+        try {
+            // Decode the event
+            ObjectMapper mapper = new ObjectMapper();
+            Event commonEvent = mapper.readValue(messageBody, Event.class);
+
+            Class<?> clazz = Class.forName(commonEvent.getEventClass());
+            Event concreteEvent = (Event)(mapper.readValue(messageBody, clazz));
+            
+            if (concreteEvent.getPersistent()) {
+                // Persist the event properties in the database ...
+                System.out.println("Persisting event in DB ...");
+            }
+            
+            // Maybe perform an action based on the event type ...
+            
+            if (concreteEvent instanceof ComputedSize) {
+                
+                // Update the deposit with the computed size
+                ComputedSize computedSizeEvent = (ComputedSize)concreteEvent;
+                Deposit deposit = depositsService.getDeposit(computedSizeEvent.getDepositId());
+                deposit.setSize(computedSizeEvent.getBytes());
+                depositsService.updateDeposit(deposit);
+                
+                // Add to the cumulative vault size
+                // TODO: locking?
+                Vault vault = deposit.getVault();
+                long vaultSize = vault.getSize();
+                vault.setSize(vaultSize + computedSizeEvent.getBytes());
+                vaultsService.updateVault(vault);
+            }
+            
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
@@ -3,6 +3,7 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:mvc="http://www.springframework.org/schema/mvc"
        xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:rabbit="http://www.springframework.org/schema/rabbit"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/context
@@ -10,7 +11,9 @@
         http://www.springframework.org/schema/mvc
         http://www.springframework.org/schema/mvc/spring-mvc.xsd
         http://www.springframework.org/schema/tx
-        http://www.springframework.org/schema/tx/spring-tx.xsd">
+        http://www.springframework.org/schema/tx/spring-tx.xsd
+        http://www.springframework.org/schema/rabbit
+        http://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd">
 
     <context:component-scan base-package="org.datavault.broker.controllers"/>
 
@@ -79,6 +82,37 @@
     <bean id="metadataService" class="org.datavault.broker.services.MetadataService">
         <property name="metaDir" value="${metaDir}"/>
     </bean>
+
+    <!-- RabbitMQ -->
+    
+    <bean id="connectionFactory"
+        class="org.springframework.amqp.rabbit.connection.CachingConnectionFactory">
+        <constructor-arg value="${queueServer}" />
+        <property name="username" value="${queueUser}" />
+        <property name="password" value="${queuePassword}" />
+    </bean>
+    
+    <!--
+    <rabbit:template id="amqpTemplate" connection-factory="connectionFactory" />
+    -->
+    
+    <rabbit:admin connection-factory="connectionFactory" />
+    
+    <rabbit:queue id="eventQueue" name="${eventQueueName}" />
+    
+    <!--
+    <rabbit:direct-exchange id="exchange" name="">
+        <rabbit:bindings>
+            <rabbit:binding queue="eventQueue" key="${eventQueueName}"></rabbit:binding>
+        </rabbit:bindings>
+    </rabbit:direct-exchange>
+    -->
+    
+    <rabbit:listener-container connection-factory="connectionFactory" >
+        <rabbit:listener ref="listener" method="listen" queue-names="eventQueue" />
+    </rabbit:listener-container>
+
+    <bean id="listener" class="org.datavault.queue.EventListener" />
 
     <bean id="sender" class="org.datavault.queue.Sender">
         <property name="queueServer" value="${queueServer}"/>

--- a/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
@@ -110,7 +110,10 @@
         <rabbit:listener ref="listener" queues="eventQueue" admin="amqpAdmin" />
     </rabbit:listener-container>
 
-    <bean id="listener" class="org.datavault.queue.EventListener" />
+    <bean id="listener" class="org.datavault.queue.EventListener">
+        <property name="vaultsService" ref="vaultsService" />
+        <property name="depositsService" ref="depositsService" />
+    </bean>
 
     <bean id="sender" class="org.datavault.queue.Sender">
         <property name="queueServer" value="${queueServer}"/>

--- a/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
@@ -13,7 +13,7 @@
         http://www.springframework.org/schema/tx
         http://www.springframework.org/schema/tx/spring-tx.xsd
         http://www.springframework.org/schema/rabbit
-        http://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd">
+        http://www.springframework.org/schema/rabbit/spring-rabbit-1.4.xsd">
 
     <context:component-scan base-package="org.datavault.broker.controllers"/>
 
@@ -92,16 +92,14 @@
         <property name="password" value="${queuePassword}" />
     </bean>
     
-    <!--
     <rabbit:template id="amqpTemplate" connection-factory="connectionFactory" />
-    -->
     
-    <rabbit:admin connection-factory="connectionFactory" />
+    <rabbit:admin id="amqpAdmin" connection-factory="connectionFactory" />
     
-    <rabbit:queue id="eventQueue" name="${eventQueueName}" />
+    <rabbit:queue id="eventQueue" name="${eventQueueName}" durable="false" />
     
     <!--
-    <rabbit:direct-exchange id="exchange" name="">
+    <rabbit:direct-exchange id="exchange">
         <rabbit:bindings>
             <rabbit:binding queue="eventQueue" key="${eventQueueName}"></rabbit:binding>
         </rabbit:bindings>
@@ -109,7 +107,7 @@
     -->
     
     <rabbit:listener-container connection-factory="connectionFactory" >
-        <rabbit:listener ref="listener" method="listen" queue-names="eventQueue" />
+        <rabbit:listener ref="listener" queues="eventQueue" admin="amqpAdmin" />
     </rabbit:listener-container>
 
     <bean id="listener" class="org.datavault.queue.EventListener" />

--- a/datavault-broker/src/main/webapp/WEB-INF/log4j.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/log4j.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN" "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+<!-- Appenders -->
+<appender name="console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.out" />
+    <layout class="org.apache.log4j.PatternLayout">
+        <param name="ConversionPattern" value="%-5p: %c - %m%n" />
+    </layout>
+</appender>
+
+<!--  Loggers -->
+<logger name="org.springframework.core">
+    <level value="info" />      
+</logger>
+
+<logger name="org.springframework.beans">
+    <level value="info" />      
+</logger>
+
+<logger name="org.springframework.context">
+    <level value="info" />      
+</logger>
+
+<logger name="org.springframework.web">
+    <level value="info" />      
+</logger>
+
+<!-- Root Logger -->
+<root>
+    <priority value="warn" />
+    <appender-ref ref="console" />
+</root>
+
+</log4j:configuration>

--- a/datavault-broker/src/main/webapp/WEB-INF/web.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/web.xml
@@ -3,6 +3,15 @@
          xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee
 	http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
 
+    <listener>
+        <listener-class>org.springframework.web.util.Log4jConfigListener</listener-class>
+    </listener>
+
+    <context-param>
+        <param-name>log4jConfigLocation</param-name>
+        <param-value>/WEB-INF/log4j.xml</param-value>
+    </context-param>
+    
     <display-name>datavault-broker</display-name>
 
     <!-- First lets tell Spring about any files other than the default servlet one -->

--- a/datavault-common/src/main/java/org/datavault/common/event/Event.java
+++ b/datavault-common/src/main/java/org/datavault/common/event/Event.java
@@ -1,5 +1,8 @@
 package org.datavault.common.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Event {
     
     // A generic event
@@ -10,7 +13,7 @@ public class Event {
     
     // By default events aren't persisted
     public Boolean persistent = false;
-
+    
     public Event() {};
     public Event(String depositId, String message) {
         this.eventClass = Event.class.getCanonicalName();

--- a/datavault-common/src/main/java/org/datavault/common/event/Event.java
+++ b/datavault-common/src/main/java/org/datavault/common/event/Event.java
@@ -1,0 +1,52 @@
+package org.datavault.common.event;
+
+public class Event {
+    
+    // A generic event
+    
+    public String eventClass;
+    public String depositId;
+    public String message;
+    
+    // By default events aren't persisted
+    public Boolean persistent = false;
+
+    public Event() {};
+    public Event(String depositId, String message) {
+        this.eventClass = Event.class.getCanonicalName();
+        this.depositId = depositId;
+        this.message = message;
+    }
+
+    public String getEventClass() {
+        return eventClass;
+    }
+
+    public void setEventClass(String eventClass) {
+        this.eventClass = eventClass;
+    }
+    
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getDepositId() {
+        return depositId;
+    }
+
+    public void setDepositId(String depositId) {
+        this.depositId = depositId;
+    }
+
+    public Boolean getPersistent() {
+        return persistent;
+    }
+
+    public void setPersistent(Boolean persistent) {
+        this.persistent = persistent;
+    }
+}

--- a/datavault-common/src/main/java/org/datavault/common/event/EventStream.java
+++ b/datavault-common/src/main/java/org/datavault/common/event/EventStream.java
@@ -1,0 +1,7 @@
+package org.datavault.common.event;
+
+public interface EventStream {
+    
+    public void send(Event event);
+    
+}

--- a/datavault-common/src/main/java/org/datavault/common/event/deposit/ComputedSize.java
+++ b/datavault-common/src/main/java/org/datavault/common/event/deposit/ComputedSize.java
@@ -2,14 +2,14 @@ package org.datavault.common.event.deposit;
 
 import org.datavault.common.event.Event;
 
-public class NotifySize extends Event {
+public class ComputedSize extends Event {
     
     public long bytes;
 
-    NotifySize() {};
-    public NotifySize(String depositId, long bytes) {
+    ComputedSize() {};
+    public ComputedSize(String depositId, long bytes) {
         super(depositId, null);
-        this.eventClass = NotifySize.class.getCanonicalName();
+        this.eventClass = ComputedSize.class.getCanonicalName();
         this.bytes = bytes;
     }
     

--- a/datavault-common/src/main/java/org/datavault/common/event/deposit/NotifySize.java
+++ b/datavault-common/src/main/java/org/datavault/common/event/deposit/NotifySize.java
@@ -1,0 +1,23 @@
+package org.datavault.common.event.deposit;
+
+import org.datavault.common.event.Event;
+
+public class NotifySize extends Event {
+    
+    public long bytes;
+
+    NotifySize() {};
+    public NotifySize(String depositId, long bytes) {
+        super(depositId, null);
+        this.eventClass = NotifySize.class.getCanonicalName();
+        this.bytes = bytes;
+    }
+    
+    public long getBytes() {
+        return bytes;
+    }
+
+    public void setBytes(long bytes) {
+        this.bytes = bytes;
+    }
+}

--- a/datavault-common/src/main/java/org/datavault/common/job/Context.java
+++ b/datavault-common/src/main/java/org/datavault/common/job/Context.java
@@ -1,6 +1,8 @@
 package org.datavault.common.job;
 
-// Some common file properties needed for all jobs
+import org.datavault.common.event.EventStream;
+
+// Some common properties needed for all jobs
 
 public class Context {
 
@@ -8,13 +10,15 @@ public class Context {
     private String tempDir;
     private String activeDir;
     private String metaDir;
+    private EventStream eventStream;
     
     public Context() {};
-    public Context(String archiveDir, String tempDir, String activeDir, String metaDir) {
+    public Context(String archiveDir, String tempDir, String activeDir, String metaDir, EventStream eventStream) {
         this.archiveDir = archiveDir;
         this.tempDir = tempDir;
         this.activeDir = activeDir;
         this.metaDir = metaDir;
+        this.eventStream = eventStream;
     }
 
     public String getArchiveDir() {
@@ -47,5 +51,13 @@ public class Context {
 
     public void setMetaDir(String metaDir) {
         this.metaDir = metaDir;
+    }
+
+    public EventStream getEventStream() {
+        return eventStream;
+    }
+
+    public void setEventStream(EventStream eventStream) {
+        this.eventStream = eventStream;
     }
 }

--- a/datavault-common/src/main/java/org/datavault/common/model/Deposit.java
+++ b/datavault-common/src/main/java/org/datavault/common/model/Deposit.java
@@ -49,6 +49,9 @@ public class Deposit {
     // Record the file path that the user selected for this deposit.
     private String filePath;
     
+    // Size of the deposit (in bytes)
+    private long depositSize;
+    
     public Deposit() {}
     public Deposit(String note) {
         this.note = note;
@@ -94,4 +97,10 @@ public class Deposit {
     public void setFilePath(String filePath) {
         this.filePath = filePath;
     }
+    
+    public void setSize(long size) {
+        this.depositSize = size;
+    }
+
+    public long getSize() { return depositSize; }
 }

--- a/datavault-common/src/main/java/org/datavault/common/model/Vault.java
+++ b/datavault-common/src/main/java/org/datavault/common/model/Vault.java
@@ -48,7 +48,7 @@ public class Vault {
     // Description of the vault
     private String description;
 
-    // Size of the vault
+    // Size of the vault (in bytes)
     private long vaultSize;
     
     // A vault can contain a number of deposits

--- a/datavault-common/src/main/java/org/datavault/common/model/dao/VaultDAO.java
+++ b/datavault-common/src/main/java/org/datavault/common/model/dao/VaultDAO.java
@@ -7,6 +7,8 @@ public interface VaultDAO {
 
     public void save(Vault vault);
     
+    public void update(Vault vault);
+    
     public List<Vault> list();
 
     public Vault findById(String Id);

--- a/datavault-common/src/main/java/org/datavault/common/model/dao/VaultDAOImpl.java
+++ b/datavault-common/src/main/java/org/datavault/common/model/dao/VaultDAOImpl.java
@@ -27,6 +27,15 @@ public class VaultDAOImpl implements VaultDAO {
         session.close();
     }
  
+    @Override
+    public void update(Vault vault) {
+        Session session = this.sessionFactory.openSession();
+        Transaction tx = session.beginTransaction();
+        session.update(vault);
+        tx.commit();
+        session.close();
+    }
+    
     @SuppressWarnings("unchecked")
     @Override
     public List<Vault> list() {        

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/deposit.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/deposit.ftl
@@ -9,12 +9,14 @@
                 <tr class="tr">
                     <th>ID</th>
                     <th>Note</th>
+                    <th>Size (bytes)</th>
                     <th>Timestamp</th>
                 </tr>
                 <tbody>
                     <tr class="tr">
                         <td>${deposit.getID()}</td>
                         <td>${deposit.note}</td>
+                        <td>${vault.size}</td>
                         <td>${deposit.creationTime?datetime}</td>
                     </tr>
                 </tbody>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/deposit.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/deposit.ftl
@@ -16,7 +16,7 @@
                     <tr class="tr">
                         <td>${deposit.getID()}</td>
                         <td>${deposit.note}</td>
-                        <td>${vault.size}</td>
+                        <td>${deposit.size}</td>
                         <td>${deposit.creationTime?datetime}</td>
                     </tr>
                 </tbody>

--- a/datavault-worker/src/main/java/org/datavault/worker/Main.java
+++ b/datavault-worker/src/main/java/org/datavault/worker/Main.java
@@ -1,22 +1,25 @@
 package org.datavault.worker;
 
 import org.datavault.worker.queue.Receiver;
+import org.datavault.worker.queue.EventSender;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 public class Main {
 
     private Receiver receiver;
+    private EventSender eventSender;
 
     public static void main(String [] args) {
 
         ApplicationContext context = new ClassPathXmlApplicationContext(new String[] {"config.xml"});
 
+        EventSender eventSender = context.getBean(EventSender.class);
         Receiver receiver = context.getBean(Receiver.class);
 
         // Listen to the message queue ...
         try {
-            receiver.receive();
+            receiver.receive(eventSender);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/datavault-worker/src/main/java/org/datavault/worker/jobs/Deposit.java
+++ b/datavault-worker/src/main/java/org/datavault/worker/jobs/Deposit.java
@@ -13,7 +13,7 @@ import org.datavault.worker.queue.EventSender;
 
 import org.apache.commons.io.FileUtils;
 import org.datavault.common.event.Event;
-import org.datavault.common.event.deposit.NotifySize;
+import org.datavault.common.event.deposit.ComputedSize;
 
 
 public class Deposit extends Job {
@@ -64,7 +64,7 @@ public class Deposit extends Job {
                     bytes = FileUtils.sizeOfDirectory(outputFile);
                 }
                 
-                eventStream.send(new NotifySize(depositId, bytes));
+                eventStream.send(new ComputedSize(depositId, bytes));
                 
                 System.out.println("\tSize: " + bytes + " bytes (" +  FileUtils.byteCountToDisplaySize(bytes) + ")");
                 

--- a/datavault-worker/src/main/java/org/datavault/worker/jobs/Deposit.java
+++ b/datavault-worker/src/main/java/org/datavault/worker/jobs/Deposit.java
@@ -40,14 +40,20 @@ public class Deposit extends Job {
                 // Copy the target file to the bag directory
                 System.out.println("\tCopying target to bag directory ...");
                 String fileName = inputFile.getName();
-                Path outputPath = bagPath.resolve(fileName);
+                File outputFile = bagPath.resolve(fileName).toFile();
 
+                long bytes = 0;
+                
                 if (inputFile.isFile()) {
-                    FileUtils.copyFile(inputFile, outputPath.toFile());
+                    FileUtils.copyFile(inputFile, outputFile);
+                    bytes = FileUtils.sizeOf(outputFile);
                 } else if (inputFile.isDirectory()) {
-                    FileUtils.copyDirectory(inputFile, outputPath.toFile());
+                    FileUtils.copyDirectory(inputFile, outputFile);
+                    bytes = FileUtils.sizeOfDirectory(outputFile);
                 }
-
+                
+                System.out.println("\tSize: " + bytes + " bytes (" +  FileUtils.byteCountToDisplaySize(bytes) + ")");
+                
                 // Bag the directory in-place
                 System.out.println("\tCreating bag ...");
                 Packager.createBag(bagDir);

--- a/datavault-worker/src/main/java/org/datavault/worker/queue/EventSender.java
+++ b/datavault-worker/src/main/java/org/datavault/worker/queue/EventSender.java
@@ -1,0 +1,60 @@
+package org.datavault.worker.queue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.Channel;
+
+import org.datavault.common.event.Event;
+import org.datavault.common.event.EventStream;
+
+public class EventSender implements EventStream {
+
+    private String queueServer;
+    private String eventQueueName;
+    private String queueUser;
+    private String queuePassword;
+
+    public void setQueueServer(String queueServer) {
+        this.queueServer = queueServer;
+    }
+
+    public void setEventQueueName(String eventQueueName) {
+        this.eventQueueName = eventQueueName;
+    }
+
+    public void setQueueUser(String queueUser) {
+        this.queueUser = queueUser;
+    }
+
+    public void setQueuePassword(String queuePassword) {
+        this.queuePassword = queuePassword;
+    }
+    
+    @Override
+    public void send(Event event) {
+        
+        try {
+            // TODO: should create queue once and keep open?
+            ConnectionFactory factory = new ConnectionFactory();
+            factory.setHost(queueServer);
+            factory.setUsername(queueUser);
+            factory.setPassword(queuePassword);
+
+            Connection connection = factory.newConnection();
+            Channel channel = connection.createChannel();
+
+            ObjectMapper mapper = new ObjectMapper();
+            String jsonEvent = mapper.writeValueAsString(event);
+
+            channel.queueDeclare(eventQueueName, false, false, false, null);
+            channel.basicPublish("", eventQueueName, null, jsonEvent.getBytes());
+            System.out.println(" [x] Sent '" + jsonEvent + "'");
+
+            channel.close();
+            connection.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/datavault-worker/src/main/java/org/datavault/worker/queue/Receiver.java
+++ b/datavault-worker/src/main/java/org/datavault/worker/queue/Receiver.java
@@ -54,7 +54,7 @@ public class Receiver {
         this.metaDir = metaDir;
     }
 
-    public void receive() throws IOException, InterruptedException, TimeoutException {
+    public void receive(EventSender events) throws IOException, InterruptedException, TimeoutException {
 
         ConnectionFactory factory = new ConnectionFactory();
         factory.setHost(queueServer);
@@ -84,7 +84,7 @@ public class Receiver {
                 Class<?> clazz = Class.forName(commonjob.getJobClass());
                 Job concreteJob = (Job)(mapper.readValue(message, clazz));
                 
-                Context context = new Context(archiveDir, tempDir, activeDir, metaDir);
+                Context context = new Context(archiveDir, tempDir, activeDir, metaDir, events);
                 concreteJob.performAction(context);
                 
             } catch (Exception e) {

--- a/datavault-worker/src/main/resources/config/config.xml
+++ b/datavault-worker/src/main/resources/config/config.xml
@@ -15,4 +15,11 @@
         <property name="metaDir" value="${metaDir}"/>
     </bean>
 
+    <bean id="eventSender" class="org.datavault.worker.queue.EventSender">
+        <property name="queueServer" value="${queueServer}"/>
+        <property name="eventQueueName" value="${eventQueueName}"/>
+        <property name="queueUser" value="${queueUser}"/>
+        <property name="queuePassword" value="${queuePassword}"/>
+    </bean>
+
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <spring.version>4.1.4.RELEASE</spring.version>
+        <spring-rabbit.version>1.4.5.RELEASE</spring-rabbit.version>
         <hibernate.version>4.3.10.Final</hibernate.version>
         <mysql.version>5.1.35</mysql.version>
         <root.basedir>${basedir}</root.basedir>
@@ -115,6 +116,12 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-tx</artifactId>
                 <version>${spring.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.amqp</groupId>
+                <artifactId>spring-rabbit</artifactId>
+                <version>${spring-rabbit.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Added an MQ listener to the broker which subscribes to a new "datavault-event" queue. This allows the worker(s) to send a stream of events to be persisted or to reflect the progress of a job.

A simple event to record the size of the deposits has been added - this allows the corresponding vault and deposit objects to by updated with a byte count as seen by the worker.

Events are handled similarly to Jobs - they inherit from a simple generic Event class and are JSON serialised/deserialised according to an embedded class name. We may wish to swap this system out in future.