### PR TITLE
Store vault/deposit metadata in bags

### DIFF
--- a/datavault-broker/src/main/java/org/datavault/broker/controllers/VaultsController.java
+++ b/datavault-broker/src/main/java/org/datavault/broker/controllers/VaultsController.java
@@ -122,13 +122,20 @@ public class VaultsController {
         
         // Ask the worker to process the deposit
         try {
+            ObjectMapper mapper = new ObjectMapper();
+
             HashMap<String, String> depositProperties = new HashMap<>();
             depositProperties.put("depositId", deposit.getID());
             depositProperties.put("bagId", deposit.getBagId());
             depositProperties.put("filePath", path.toString()); // The absolute path
             
+            // Deposit and Vault metadata
+            // TODO: at the moment we're just serialising the objects to JSON.
+            // In future we'll need a more formal schema/representation (e.g. RDF or JSON-LD).
+            depositProperties.put("depositMetadata", mapper.writeValueAsString(deposit));
+            depositProperties.put("vaultMetadata", mapper.writeValueAsString(vault));
+            
             Job depositJob = new Job("org.datavault.worker.jobs.Deposit", depositProperties);
-            ObjectMapper mapper = new ObjectMapper();
             String jsonDeposit = mapper.writeValueAsString(depositJob);
             sender.send(jsonDeposit);
         } catch (Exception e) {

--- a/datavault-worker/src/main/java/org/datavault/worker/jobs/Deposit.java
+++ b/datavault-worker/src/main/java/org/datavault/worker/jobs/Deposit.java
@@ -33,6 +33,11 @@ public class Deposit extends Job {
         String bagID = properties.get("bagId");
         String filePath = properties.get("filePath");
         
+        // Deposit and Vault metadata to be stored in the bag
+        // TODO: is there a better way to pass this to the worker?
+        String depositMetadata = properties.get("depositMetadata");
+        String vaultMetadata = properties.get("vaultMetadata");
+        
         eventStream.send(new Event(depositId, "Deposit started"));
         
         System.out.println("\tbagID: " + bagID);
@@ -73,6 +78,9 @@ public class Deposit extends Job {
                 System.out.println("\tCreating bag ...");
                 Packager.createBag(bagDir);
 
+                // Add vault/deposit metadata to the bag
+                Packager.addMetadata(bagDir, depositMetadata, vaultMetadata);
+                
                 // Tar the bag directory
                 System.out.println("\tCreating tar file ...");
                 String tarFileName = bagID + ".tar";
@@ -87,7 +95,7 @@ public class Deposit extends Job {
                 
                 // Copy bag meta files to the meta directory
                 System.out.println("\tCopying meta files ...");
-                Packager.extractMetaFiles(bagDir, metaDir);
+                Packager.extractMetadata(bagDir, metaDir);
                 
                 // Copy the resulting tar file to the archive area
                 System.out.println("\tCopying tar file to archive ...");

--- a/datavault-worker/src/main/java/org/datavault/worker/operations/Packager.java
+++ b/datavault-worker/src/main/java/org/datavault/worker/operations/Packager.java
@@ -10,6 +10,9 @@ import org.apache.commons.io.FileUtils;
 import gov.loc.repository.bagit.*;
 
 public class Packager {
+
+    public static final String depositMetaFileName = "deposit.json";
+    public static final String vaultMetaFileName = "vault.json";
     
     // Create a bag from an existing directory.
     public static boolean createBag(File dir) throws Exception {
@@ -28,12 +31,47 @@ public class Packager {
         return result;
     }
     
+    // Add vault/deposit metadata
+    public static boolean addMetadata(File bagDir, String depositMetadata, String vaultMetadata) {
+        
+        boolean result = false;
+        
+        try {
+            Path bagPath = bagDir.toPath();
+
+            // Create an empty "metadata" directory
+            Path metadataDirPath = bagPath.resolve("metadata");
+            File metadataDir = metadataDirPath.toFile();
+            metadataDir.mkdir();
+
+            // Add deposit metadata
+            File depositMetaFile = metadataDirPath.resolve(depositMetaFileName).toFile();
+            FileUtils.writeStringToFile(depositMetaFile, depositMetadata);
+
+            // Add vault metadata
+            File vaultMetaFile = metadataDirPath.resolve(vaultMetaFileName).toFile();
+            FileUtils.writeStringToFile(vaultMetaFile, vaultMetadata);
+
+            // Add to manifest
+            // ...
+
+            // Metadata files created
+            result = true;
+            
+        } catch (IOException e) {
+            System.out.println(e.toString());
+            result = false;
+        }
+        
+        return result;
+    }
+    
     // Extract the top-level metadata files from a bag and copy to a new directory.
-    public static boolean extractMetaFiles(File bagDir, File metaDir) {
+    public static boolean extractMetadata(File bagDir, File metaDir) {
         
         // TODO: could we use the built-in "holey" bag methods instead?
         
-        boolean result;
+        boolean result = false;
         Path bagPath = bagDir.toPath();
         
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(bagPath)) {

--- a/datavault-worker/src/main/java/org/datavault/worker/operations/Packager.java
+++ b/datavault-worker/src/main/java/org/datavault/worker/operations/Packager.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.apache.commons.io.FileUtils;
 import gov.loc.repository.bagit.*;
 
@@ -45,12 +46,24 @@ public class Packager {
                 - bagit.txt
                 - manifest-md5.txt
                 - tagmanifest-md5.txt
+                - other metadata files or directories
                 */
                 
                 String entryFileName = entry.getFileName().toString();
+
+                if (Files.isDirectory(entry)) {
+                    // Handle directories
+                    if (entryFileName.equals("data")) {
+                        // Create an empty "data" directory
+                        Path metaDirPath = Paths.get(metaDir.toURI());
+                        File emptyDataDir = metaDirPath.resolve("data").toFile();
+                        emptyDataDir.mkdir();
+                    } else {
+                        FileUtils.copyDirectoryToDirectory(entry.toFile(), metaDir);
+                    }
                 
-                // Copy any regular text files at the top level (but not directories)
-                if (!Files.isDirectory(entry) && entryFileName.endsWith(".txt")) {
+                } else if (!Files.isDirectory(entry)) {
+                    // Handle files
                     FileUtils.copyFileToDirectory(entry.toFile(), metaDir);
                 }
             }


### PR DESCRIPTION
Initial (simple) serialisation of objects to JSON. The vault/deposit
information is stored in a new top-level "metadata" directory in the
bag.

In future we should probably use a RDF or JSON-LD representation of
metadata (perhaps use the ORE schema/fields?).

Tag metadata (e.g. md5 fixity) also needs to be added for these new
files.