### PR TITLE
Add basic tracking of transfer progress

### DIFF
--- a/datavault-broker/src/main/java/org/datavault/queue/EventListener.java
+++ b/datavault-broker/src/main/java/org/datavault/queue/EventListener.java
@@ -68,6 +68,13 @@ public class EventListener implements MessageListener {
                 vault.setSize(vaultSize + computedSizeEvent.getBytes());
                 vaultsService.updateVault(vault);
                 
+            } else if (concreteEvent instanceof TransferProgress) {
+                
+                // Update the deposit transfer progress
+                TransferProgress transferProgressEvent = (TransferProgress)concreteEvent;
+                deposit.setBytesTransferred(transferProgressEvent.getBytes());
+                depositsService.updateDeposit(deposit);
+                
             } else if (concreteEvent instanceof Complete) {
                 
                 // Update the deposit status

--- a/datavault-common/pom.xml
+++ b/datavault-common/pom.xml
@@ -27,5 +27,12 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>
+
+        <!-- Apache Commons IO -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
+        </dependency>
     </dependencies>
 </project>

--- a/datavault-common/src/main/java/org/datavault/common/event/deposit/TransferProgress.java
+++ b/datavault-common/src/main/java/org/datavault/common/event/deposit/TransferProgress.java
@@ -1,0 +1,24 @@
+package org.datavault.common.event.deposit;
+
+import org.datavault.common.event.Event;
+
+public class TransferProgress extends Event {
+    
+    public long bytes;
+
+    TransferProgress() {};
+    public TransferProgress(String depositId, long bytes) {
+        super(depositId, "Bytes transferred: " + bytes + " bytes");
+        this.eventClass = TransferProgress.class.getCanonicalName();
+        this.bytes = bytes;
+        this.persistent = false;
+    }
+    
+    public long getBytes() {
+        return bytes;
+    }
+
+    public void setBytes(long bytes) {
+        this.bytes = bytes;
+    }
+}

--- a/datavault-common/src/main/java/org/datavault/common/io/FileCopy.java
+++ b/datavault-common/src/main/java/org/datavault/common/io/FileCopy.java
@@ -1,0 +1,522 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Originally from Apache Commons IO 2.4
+ * Modified version of FileUtils to add progress/error tracking to file copies.
+ */
+package org.datavault.common.io;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.io.*;
+
+public class FileCopy {
+
+    /**
+     * Instances should NOT be constructed in standard programming.
+     */
+    public FileCopy() {
+        super();
+    }
+    
+    /**
+     * The number of bytes in a kilobyte.
+     */
+    public static final long ONE_KB = 1024;
+    
+    /**
+     * The number of bytes in a megabyte.
+     */
+    public static final long ONE_MB = ONE_KB * ONE_KB;
+    
+    /**
+     * The file copy buffer size (30 MB)
+     */
+    private static final long FILE_COPY_BUFFER_SIZE = ONE_MB * 30;
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Copies a file to a directory preserving the file date.
+     * <p>
+     * This method copies the contents of the specified source file
+     * to a file of the same name in the specified destination directory.
+     * The destination directory is created if it does not exist.
+     * If the destination file exists, then this method will overwrite it.
+     * <p>
+     * <strong>Note:</strong> This method tries to preserve the file's last
+     * modified date/times using {@link File#setLastModified(long)}, however
+     * it is not guaranteed that the operation will succeed.
+     * If the modification operation fails, no indication is provided.
+     *
+     * @param srcFile  an existing file to copy, must not be {@code null}
+     * @param destDir  the directory to place the copy in, must not be {@code null}
+     *
+     * @throws NullPointerException if source or destination is null
+     * @throws IOException if source or destination is invalid
+     * @throws IOException if an IO error occurs during copying
+     * @see #copyFile(File, File, boolean)
+     */
+    public static void copyFileToDirectory(Progress progress, File srcFile, File destDir) throws IOException {
+        copyFileToDirectory(progress, srcFile, destDir, true);
+    }
+
+    /**
+     * Copies a file to a directory optionally preserving the file date.
+     * <p>
+     * This method copies the contents of the specified source file
+     * to a file of the same name in the specified destination directory.
+     * The destination directory is created if it does not exist.
+     * If the destination file exists, then this method will overwrite it.
+     * <p>
+     * <strong>Note:</strong> Setting <code>preserveFileDate</code> to
+     * {@code true} tries to preserve the file's last modified
+     * date/times using {@link File#setLastModified(long)}, however it is
+     * not guaranteed that the operation will succeed.
+     * If the modification operation fails, no indication is provided.
+     *
+     * @param srcFile  an existing file to copy, must not be {@code null}
+     * @param destDir  the directory to place the copy in, must not be {@code null}
+     * @param preserveFileDate  true if the file date of the copy
+     *  should be the same as the original
+     *
+     * @throws NullPointerException if source or destination is {@code null}
+     * @throws IOException if source or destination is invalid
+     * @throws IOException if an IO error occurs during copying
+     * @see #copyFile(File, File, boolean)
+     * @since 1.3
+     */
+    public static void copyFileToDirectory(Progress progress, File srcFile, File destDir, boolean preserveFileDate) throws IOException {
+        if (destDir == null) {
+            throw new NullPointerException("Destination must not be null");
+        }
+        if (destDir.exists() && destDir.isDirectory() == false) {
+            throw new IllegalArgumentException("Destination '" + destDir + "' is not a directory");
+        }
+        File destFile = new File(destDir, srcFile.getName());
+        copyFile(progress, srcFile, destFile, preserveFileDate);
+    }
+
+    /**
+     * Copies a file to a new location preserving the file date.
+     * <p>
+     * This method copies the contents of the specified source file to the
+     * specified destination file. The directory holding the destination file is
+     * created if it does not exist. If the destination file exists, then this
+     * method will overwrite it.
+     * <p>
+     * <strong>Note:</strong> This method tries to preserve the file's last
+     * modified date/times using {@link File#setLastModified(long)}, however
+     * it is not guaranteed that the operation will succeed.
+     * If the modification operation fails, no indication is provided.
+     * 
+     * @param srcFile  an existing file to copy, must not be {@code null}
+     * @param destFile  the new file, must not be {@code null}
+     * 
+     * @throws NullPointerException if source or destination is {@code null}
+     * @throws IOException if source or destination is invalid
+     * @throws IOException if an IO error occurs during copying
+     * @see #copyFileToDirectory(File, File)
+     */
+    public static void copyFile(Progress progress, File srcFile, File destFile) throws IOException {
+        copyFile(progress, srcFile, destFile, true);
+    }
+
+    /**
+     * Copies a file to a new location.
+     * <p>
+     * This method copies the contents of the specified source file
+     * to the specified destination file.
+     * The directory holding the destination file is created if it does not exist.
+     * If the destination file exists, then this method will overwrite it.
+     * <p>
+     * <strong>Note:</strong> Setting <code>preserveFileDate</code> to
+     * {@code true} tries to preserve the file's last modified
+     * date/times using {@link File#setLastModified(long)}, however it is
+     * not guaranteed that the operation will succeed.
+     * If the modification operation fails, no indication is provided.
+     *
+     * @param srcFile  an existing file to copy, must not be {@code null}
+     * @param destFile  the new file, must not be {@code null}
+     * @param preserveFileDate  true if the file date of the copy
+     *  should be the same as the original
+     *
+     * @throws NullPointerException if source or destination is {@code null}
+     * @throws IOException if source or destination is invalid
+     * @throws IOException if an IO error occurs during copying
+     * @see #copyFileToDirectory(File, File, boolean)
+     */
+    public static void copyFile(Progress progress, File srcFile, File destFile,
+            boolean preserveFileDate) throws IOException {
+        if (srcFile == null) {
+            throw new NullPointerException("Source must not be null");
+        }
+        if (destFile == null) {
+            throw new NullPointerException("Destination must not be null");
+        }
+        if (srcFile.exists() == false) {
+            throw new FileNotFoundException("Source '" + srcFile + "' does not exist");
+        }
+        if (srcFile.isDirectory()) {
+            throw new IOException("Source '" + srcFile + "' exists but is a directory");
+        }
+        if (srcFile.getCanonicalPath().equals(destFile.getCanonicalPath())) {
+            throw new IOException("Source '" + srcFile + "' and destination '" + destFile + "' are the same");
+        }
+        File parentFile = destFile.getParentFile();
+        if (parentFile != null) {
+            if (!parentFile.mkdirs() && !parentFile.isDirectory()) {
+                throw new IOException("Destination '" + parentFile + "' directory cannot be created");
+            }
+        }
+        if (destFile.exists() && destFile.canWrite() == false) {
+            throw new IOException("Destination '" + destFile + "' exists but is read-only");
+        }
+        doCopyFile(progress, srcFile, destFile, preserveFileDate);
+    }
+    
+    /**
+     * Internal copy file method.
+     * 
+     * @param srcFile  the validated source file, must not be {@code null}
+     * @param destFile  the validated destination file, must not be {@code null}
+     * @param preserveFileDate  whether to preserve the file date
+     * @throws IOException if an error occurs
+     */
+    private static void doCopyFile(Progress progress, File srcFile, File destFile, boolean preserveFileDate) throws IOException {
+        if (destFile.exists() && destFile.isDirectory()) {
+            throw new IOException("Destination '" + destFile + "' exists but is a directory");
+        }
+
+        FileInputStream fis = null;
+        FileOutputStream fos = null;
+        FileChannel input = null;
+        FileChannel output = null;
+        try {
+            fis = new FileInputStream(srcFile);
+            fos = new FileOutputStream(destFile);
+            input  = fis.getChannel();
+            output = fos.getChannel();
+            long size = input.size();
+            long pos = 0;
+            long count = 0;
+            while (pos < size) {
+                count = size - pos > FILE_COPY_BUFFER_SIZE ? FILE_COPY_BUFFER_SIZE : size - pos;
+                pos += output.transferFrom(input, pos, count);
+                progress.byteCount += count;
+            }
+        } finally {
+            IOUtils.closeQuietly(output);
+            IOUtils.closeQuietly(fos);
+            IOUtils.closeQuietly(input);
+            IOUtils.closeQuietly(fis);
+        }
+
+        if (srcFile.length() != destFile.length()) {
+            throw new IOException("Failed to copy full contents from '" +
+                    srcFile + "' to '" + destFile + "'");
+        }
+        if (preserveFileDate) {
+            destFile.setLastModified(srcFile.lastModified());
+        }
+        
+        progress.fileCount += 1;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Copies a directory to within another directory preserving the file dates.
+     * <p>
+     * This method copies the source directory and all its contents to a
+     * directory of the same name in the specified destination directory.
+     * <p>
+     * The destination directory is created if it does not exist.
+     * If the destination directory did exist, then this method merges
+     * the source with the destination, with the source taking precedence.
+     * <p>
+     * <strong>Note:</strong> This method tries to preserve the files' last
+     * modified date/times using {@link File#setLastModified(long)}, however
+     * it is not guaranteed that those operations will succeed.
+     * If the modification operation fails, no indication is provided.
+     *
+     * @param srcDir  an existing directory to copy, must not be {@code null}
+     * @param destDir  the directory to place the copy in, must not be {@code null}
+     *
+     * @throws NullPointerException if source or destination is {@code null}
+     * @throws IOException if source or destination is invalid
+     * @throws IOException if an IO error occurs during copying
+     * @since 1.2
+     */
+    public static void copyDirectoryToDirectory(Progress progress, File srcDir, File destDir) throws IOException {
+        if (srcDir == null) {
+            throw new NullPointerException("Source must not be null");
+        }
+        if (srcDir.exists() && srcDir.isDirectory() == false) {
+            throw new IllegalArgumentException("Source '" + destDir + "' is not a directory");
+        }
+        if (destDir == null) {
+            throw new NullPointerException("Destination must not be null");
+        }
+        if (destDir.exists() && destDir.isDirectory() == false) {
+            throw new IllegalArgumentException("Destination '" + destDir + "' is not a directory");
+        }
+        copyDirectory(progress, srcDir, new File(destDir, srcDir.getName()), true);
+    }
+
+    /**
+     * Copies a whole directory to a new location preserving the file dates.
+     * <p>
+     * This method copies the specified directory and all its child
+     * directories and files to the specified destination.
+     * The destination is the new location and name of the directory.
+     * <p>
+     * The destination directory is created if it does not exist.
+     * If the destination directory did exist, then this method merges
+     * the source with the destination, with the source taking precedence.
+     * <p>
+     * <strong>Note:</strong> This method tries to preserve the files' last
+     * modified date/times using {@link File#setLastModified(long)}, however
+     * it is not guaranteed that those operations will succeed.
+     * If the modification operation fails, no indication is provided.
+     *
+     * @param srcDir  an existing directory to copy, must not be {@code null}
+     * @param destDir  the new directory, must not be {@code null}
+     *
+     * @throws NullPointerException if source or destination is {@code null}
+     * @throws IOException if source or destination is invalid
+     * @throws IOException if an IO error occurs during copying
+     * @since 1.1
+     */
+    public static void copyDirectory(Progress progress, File srcDir, File destDir) throws IOException {
+        copyDirectory(progress, srcDir, destDir, true);
+    }
+
+    /**
+     * Copies a whole directory to a new location.
+     * <p>
+     * This method copies the contents of the specified source directory
+     * to within the specified destination directory.
+     * <p>
+     * The destination directory is created if it does not exist.
+     * If the destination directory did exist, then this method merges
+     * the source with the destination, with the source taking precedence.
+     * <p>
+     * <strong>Note:</strong> Setting <code>preserveFileDate</code> to
+     * {@code true} tries to preserve the files' last modified
+     * date/times using {@link File#setLastModified(long)}, however it is
+     * not guaranteed that those operations will succeed.
+     * If the modification operation fails, no indication is provided.
+     *
+     * @param srcDir  an existing directory to copy, must not be {@code null}
+     * @param destDir  the new directory, must not be {@code null}
+     * @param preserveFileDate  true if the file date of the copy
+     *  should be the same as the original
+     *
+     * @throws NullPointerException if source or destination is {@code null}
+     * @throws IOException if source or destination is invalid
+     * @throws IOException if an IO error occurs during copying
+     * @since 1.1
+     */
+    public static void copyDirectory(Progress progress, File srcDir, File destDir,
+            boolean preserveFileDate) throws IOException {
+        copyDirectory(progress, srcDir, destDir, null, preserveFileDate);
+    }
+
+    /**
+     * Copies a filtered directory to a new location preserving the file dates.
+     * <p>
+     * This method copies the contents of the specified source directory
+     * to within the specified destination directory.
+     * <p>
+     * The destination directory is created if it does not exist.
+     * If the destination directory did exist, then this method merges
+     * the source with the destination, with the source taking precedence.
+     * <p>
+     * <strong>Note:</strong> This method tries to preserve the files' last
+     * modified date/times using {@link File#setLastModified(long)}, however
+     * it is not guaranteed that those operations will succeed.
+     * If the modification operation fails, no indication is provided.
+     *
+     * <h4>Example: Copy directories only</h4> 
+     *  <pre>
+  // only copy the directory structure
+  FileCopy.copyDirectory(srcDir, destDir, DirectoryFileFilter.DIRECTORY);
+  </pre>
+     *
+     * <h4>Example: Copy directories and txt files</h4>
+     *  <pre>
+  // Create a filter for ".txt" files
+  IOFileFilter txtSuffixFilter = FileFilterUtils.suffixFileFilter(".txt");
+  IOFileFilter txtFiles = FileFilterUtils.andFileFilter(FileFileFilter.FILE, txtSuffixFilter);
+
+  // Create a filter for either directories or ".txt" files
+  FileFilter filter = FileFilterUtils.orFileFilter(DirectoryFileFilter.DIRECTORY, txtFiles);
+
+  // Copy using the filter
+  FileCopy.copyDirectory(srcDir, destDir, filter);
+  </pre>
+     *
+     * @param srcDir  an existing directory to copy, must not be {@code null}
+     * @param destDir  the new directory, must not be {@code null}
+     * @param filter  the filter to apply, null means copy all directories and files
+     *  should be the same as the original
+     *
+     * @throws NullPointerException if source or destination is {@code null}
+     * @throws IOException if source or destination is invalid
+     * @throws IOException if an IO error occurs during copying
+     * @since 1.4
+     */
+    public static void copyDirectory(Progress progress, File srcDir, File destDir,
+            FileFilter filter) throws IOException {
+        copyDirectory(progress, srcDir, destDir, filter, true);
+    }
+
+    /**
+     * Copies a filtered directory to a new location.
+     * <p>
+     * This method copies the contents of the specified source directory
+     * to within the specified destination directory.
+     * <p>
+     * The destination directory is created if it does not exist.
+     * If the destination directory did exist, then this method merges
+     * the source with the destination, with the source taking precedence.
+     * <p>
+     * <strong>Note:</strong> Setting <code>preserveFileDate</code> to
+     * {@code true} tries to preserve the files' last modified
+     * date/times using {@link File#setLastModified(long)}, however it is
+     * not guaranteed that those operations will succeed.
+     * If the modification operation fails, no indication is provided.
+     *
+     * <h4>Example: Copy directories only</h4> 
+     *  <pre>
+  // only copy the directory structure
+  FileCopy.copyDirectory(srcDir, destDir, DirectoryFileFilter.DIRECTORY, false);
+  </pre>
+     *
+     * <h4>Example: Copy directories and txt files</h4>
+     *  <pre>
+  // Create a filter for ".txt" files
+  IOFileFilter txtSuffixFilter = FileFilterUtils.suffixFileFilter(".txt");
+  IOFileFilter txtFiles = FileFilterUtils.andFileFilter(FileFileFilter.FILE, txtSuffixFilter);
+
+  // Create a filter for either directories or ".txt" files
+  FileFilter filter = FileFilterUtils.orFileFilter(DirectoryFileFilter.DIRECTORY, txtFiles);
+
+  // Copy using the filter
+  FileCopy.copyDirectory(srcDir, destDir, filter, false);
+  </pre>
+     * 
+     * @param srcDir  an existing directory to copy, must not be {@code null}
+     * @param destDir  the new directory, must not be {@code null}
+     * @param filter  the filter to apply, null means copy all directories and files
+     * @param preserveFileDate  true if the file date of the copy
+     *  should be the same as the original
+     *
+     * @throws NullPointerException if source or destination is {@code null}
+     * @throws IOException if source or destination is invalid
+     * @throws IOException if an IO error occurs during copying
+     * @since 1.4
+     */
+    public static void copyDirectory(Progress progress, File srcDir, File destDir,
+            FileFilter filter, boolean preserveFileDate) throws IOException {
+        if (srcDir == null) {
+            throw new NullPointerException("Source must not be null");
+        }
+        if (destDir == null) {
+            throw new NullPointerException("Destination must not be null");
+        }
+        if (srcDir.exists() == false) {
+            throw new FileNotFoundException("Source '" + srcDir + "' does not exist");
+        }
+        if (srcDir.isDirectory() == false) {
+            throw new IOException("Source '" + srcDir + "' exists but is not a directory");
+        }
+        if (srcDir.getCanonicalPath().equals(destDir.getCanonicalPath())) {
+            throw new IOException("Source '" + srcDir + "' and destination '" + destDir + "' are the same");
+        }
+
+        // Cater for destination being directory within the source directory (see IO-141)
+        List<String> exclusionList = null;
+        if (destDir.getCanonicalPath().startsWith(srcDir.getCanonicalPath())) {
+            File[] srcFiles = filter == null ? srcDir.listFiles() : srcDir.listFiles(filter);
+            if (srcFiles != null && srcFiles.length > 0) {
+                exclusionList = new ArrayList<String>(srcFiles.length);
+                for (File srcFile : srcFiles) {
+                    File copiedFile = new File(destDir, srcFile.getName());
+                    exclusionList.add(copiedFile.getCanonicalPath());
+                }
+            }
+        }
+        doCopyDirectory(progress, srcDir, destDir, filter, preserveFileDate, exclusionList);
+    }
+
+    /**
+     * Internal copy directory method.
+     * 
+     * @param srcDir  the validated source directory, must not be {@code null}
+     * @param destDir  the validated destination directory, must not be {@code null}
+     * @param filter  the filter to apply, null means copy all directories and files
+     * @param preserveFileDate  whether to preserve the file date
+     * @param exclusionList  List of files and directories to exclude from the copy, may be null
+     * @throws IOException if an error occurs
+     * @since 1.1
+     */
+    private static void doCopyDirectory(Progress progress, File srcDir, File destDir, FileFilter filter,
+            boolean preserveFileDate, List<String> exclusionList) throws IOException {
+        // recurse
+        File[] srcFiles = filter == null ? srcDir.listFiles() : srcDir.listFiles(filter);
+        if (srcFiles == null) {  // null if abstract pathname does not denote a directory, or if an I/O error occurs
+            throw new IOException("Failed to list contents of " + srcDir);
+        }
+        if (destDir.exists()) {
+            if (destDir.isDirectory() == false) {
+                throw new IOException("Destination '" + destDir + "' exists but is not a directory");
+            }
+        } else {
+            if (!destDir.mkdirs() && !destDir.isDirectory()) {
+                throw new IOException("Destination '" + destDir + "' directory cannot be created");
+            }
+        }
+        if (destDir.canWrite() == false) {
+            throw new IOException("Destination '" + destDir + "' cannot be written to");
+        }
+        for (File srcFile : srcFiles) {
+            File dstFile = new File(destDir, srcFile.getName());
+            if (exclusionList == null || !exclusionList.contains(srcFile.getCanonicalPath())) {
+                if (srcFile.isDirectory()) {
+                    doCopyDirectory(progress, srcFile, dstFile, filter, preserveFileDate, exclusionList);
+                } else {
+                    doCopyFile(progress, srcFile, dstFile, preserveFileDate);
+                }
+            }
+        }
+
+        // Do this last, as the above has probably affected directory metadata
+        if (preserveFileDate) {
+            destDir.setLastModified(srcDir.lastModified());
+        }
+        
+        progress.dirCount += 1;
+    }
+}

--- a/datavault-common/src/main/java/org/datavault/common/io/Progress.java
+++ b/datavault-common/src/main/java/org/datavault/common/io/Progress.java
@@ -1,0 +1,7 @@
+package org.datavault.common.io;
+
+public class Progress {
+    public long dirCount = 0;
+    public long fileCount = 0;
+    public long byteCount = 0;
+}

--- a/datavault-common/src/main/java/org/datavault/common/model/Deposit.java
+++ b/datavault-common/src/main/java/org/datavault/common/model/Deposit.java
@@ -63,6 +63,9 @@ public class Deposit {
     // Size of the deposit (in bytes)
     private long depositSize;
     
+    // Number of bytes ingested/transferred
+    private long bytesTransferred;
+    
     public Deposit() {}
     public Deposit(String note) {
         this.note = note;
@@ -114,9 +117,16 @@ public class Deposit {
     }
 
     public long getSize() { return depositSize; }
+
+    public long getBytesTransferred() {
+        return bytesTransferred;
+    }
+
+    public void setBytesTransferred(long bytesTransferred) {
+        this.bytesTransferred = bytesTransferred;
+    }
     
     public List<Event> getEvents() {
         return events;
     }
-
 }

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/deposit.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/deposit.ftl
@@ -8,6 +8,20 @@
         <li class="active"><b>Deposit:</b> ${deposit.note?html}</li>
     </ol>
 
+    <#if deposit.size == 0>
+        <#assign percentComplete = 0>
+    <#else>
+        <#assign percentComplete = (deposit.bytesTransferred / deposit.size) * 100>
+    </#if>
+
+    <#if percentComplete != 100>
+        <div class="progress">
+          <div class="progress-bar progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="${percentComplete}" aria-valuemin="0" aria-valuemax="100" style="width: ${percentComplete}%">
+            <span class="sr-only">${percentComplete}% Complete</span>
+          </div>
+        </div>
+    </#if>
+
     <ul class="nav nav-tabs">
         <li class="active"><a data-toggle="tab" href="#deposit">Deposit</a></li>
         <li><a data-toggle="tab" href="#contents">Contents <span class="badge">${manifest?size}</span></a></li>

--- a/datavault-worker/src/main/java/org/datavault/worker/operations/ProgressTracker.java
+++ b/datavault-worker/src/main/java/org/datavault/worker/operations/ProgressTracker.java
@@ -1,15 +1,22 @@
 package org.datavault.worker.operations;
 
+import org.datavault.common.event.deposit.TransferProgress;
 import org.datavault.common.io.Progress;
+import org.datavault.worker.queue.EventSender;
 
 public class ProgressTracker implements Runnable {
     
-    private static final int SLEEP_INTERVAL_MS = 100;
+    private static final int SLEEP_INTERVAL_MS = 250;
     private boolean active = true;
-    Progress progress;
     
-    public ProgressTracker(Progress progress) {
+    Progress progress;
+    String depositId;
+    EventSender eventSender;
+    
+    public ProgressTracker(Progress progress, String depositId, EventSender eventSender) {
         this.progress = progress;
+        this.depositId = depositId;
+        this.eventSender = eventSender;
     }
     
     public void stop() {
@@ -17,9 +24,17 @@ public class ProgressTracker implements Runnable {
     }
     
     void reportProgress() {
-        System.out.println("\tCopied: " + progress.dirCount + " dirs, "
-                                        + progress.fileCount + " files, "
-                                        + progress.byteCount + " bytes");
+        
+        long dirCount = progress.dirCount;
+        long fileCount = progress.fileCount;
+        long byteCount = progress.byteCount;
+        
+        System.out.println("\tCopied: " + dirCount + " dirs, "
+                                        + fileCount + " files, "
+                                        + byteCount + " bytes");
+        
+        TransferProgress progressEvent = new TransferProgress(depositId, byteCount);
+        eventSender.send(progressEvent);
     }
     
     @Override

--- a/datavault-worker/src/main/java/org/datavault/worker/operations/ProgressTracker.java
+++ b/datavault-worker/src/main/java/org/datavault/worker/operations/ProgressTracker.java
@@ -1,0 +1,40 @@
+package org.datavault.worker.operations;
+
+import org.datavault.common.io.Progress;
+
+public class ProgressTracker implements Runnable {
+    
+    private static final int SLEEP_INTERVAL_MS = 100;
+    private boolean active = true;
+    Progress progress;
+    
+    public ProgressTracker(Progress progress) {
+        this.progress = progress;
+    }
+    
+    public void stop() {
+        active = false;
+    }
+    
+    void reportProgress() {
+        System.out.println("\tCopied: " + progress.dirCount + " dirs, "
+                                        + progress.fileCount + " files, "
+                                        + progress.byteCount + " bytes");
+    }
+    
+    @Override
+    public void run() {
+        try {
+            while(active) {
+                reportProgress();
+                Thread.sleep(SLEEP_INTERVAL_MS);
+            }
+            
+            // Report final counts before exiting
+            reportProgress();
+            
+        } catch (Exception e) {
+            // ...
+        }
+    }
+}


### PR DESCRIPTION
To do this I've instrumented some of the file/directory copy methods from org.apache.commons.io.FileUtils.

Events are sent to the broker to report overall progress (the size of the copy is determined ahead of time). The transferred bytes are stored in the deposit object and are available to the client, allowing a simple progress bar to be displayed.

In future we could also display which stage the deposit is at and some more detailed information (e.g. relevant errors/warnings). A prediction of time to completion would also be valuable.