### PR TITLE
Display more user-friendly path/origin information

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/VaultsController.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/VaultsController.java
@@ -229,7 +229,7 @@ public class VaultsController {
         }
         
         // Add the deposit object
-        depositsService.addDeposit(vault, deposit);
+        depositsService.addDeposit(vault, deposit, storagePath, store.getLabel());
         
         // Create a job to track this deposit
         Job job = new Job("org.datavaultplatform.worker.tasks.Deposit");

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/DepositsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/DepositsService.java
@@ -16,13 +16,17 @@ public class DepositsService {
         return depositDAO.list();
     }
     
-    public void addDeposit(Vault vault, Deposit deposit) {
+    public void addDeposit(Vault vault, Deposit deposit, String shortPath, String origin) {
         
         Date d = new Date();
         deposit.setCreationTime(d);
         
         deposit.setVault(vault);
         deposit.setStatus(Deposit.Status.NOT_STARTED);
+        
+        // Set display values for the deposit path/origin
+        deposit.setShortFilePath(shortPath);
+        deposit.setFileOrigin(origin);
         
         // Generate a new UUID for this Bag.
         deposit.setBagId(UUID.randomUUID().toString());

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/Deposit.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/Deposit.java
@@ -68,6 +68,8 @@ public class Deposit {
     private String bagId;
     
     // Record the file path that the user selected for this deposit.
+    private String fileOrigin;
+    private String shortFilePath;
     private String filePath;
     
     // Size of the deposit (in bytes)
@@ -112,8 +114,24 @@ public class Deposit {
     public void setBagId(String bagId) {
         this.bagId = bagId;
     }
+
+    public String getFileOrigin() {
+        return fileOrigin;
+    }
+
+    public void setFileOrigin(String fileOrigin) {
+        this.fileOrigin = fileOrigin;
+    }
     
     public String getFilePath() { return filePath; }
+
+    public String getShortFilePath() {
+        return shortFilePath;
+    }
+
+    public void setShortFilePath(String shortFilePath) {
+        this.shortFilePath = shortFilePath;
+    }
     
     public void setFilePath(String filePath) {
         this.filePath = filePath;

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/vault.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/vault.ftl
@@ -37,6 +37,7 @@
                 <thead>
                     <tr class="tr">
                         <th>Deposit</th>
+                        <th>Origin</th>
                         <th>File Path</th>
                         <th>Size</th>
                         <th>Timestamp</th>
@@ -49,7 +50,8 @@
                             <td>
                                 <a href="${springMacroRequestContext.getContextPath()}/vaults/${vault.getID()}/deposits/${deposit.getID()}">${deposit.note?html}</a>
                             </td>
-                            <td>${deposit.filePath?html}</td>
+                            <td>${deposit.fileOrigin?html}</td>
+                            <td>${deposit.shortFilePath?html}</td>
                             <td>${deposit.getSizeStr()}</td>
                             <td>${deposit.getCreationTime()?datetime}</td>
                         </tr>

--- a/datavault-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/datavault-webapp/src/main/webapp/WEB-INF/web.xml
@@ -38,6 +38,7 @@
     </listener>
 
     <error-page>
+        <error-code>500</error-code>
         <location>/error</location>
     </error-page>
 


### PR DESCRIPTION
#133
Added a "short path" and an "origin" to the deposit to indicate where a file came from without displaying an UUID-prefixed full path.