### PR TITLE
Creation of a Restore object

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 brokerURL = http://localhost:8080/datavault-broker
 
-dbURL = localhost:3306/datavault
+dbURL = localhost:3307/datavault
 dbUsername = datavault
 dbPassword = datavault
 

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 brokerURL = http://localhost:8080/datavault-broker
 
-dbURL = localhost:3307/datavault
+dbURL = localhost:3306/datavault
 dbUsername = datavault
 dbPassword = datavault
 

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/RestoresService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/RestoresService.java
@@ -1,0 +1,45 @@
+package org.datavaultplatform.broker.services;
+
+import org.datavaultplatform.common.model.Deposit;
+import org.datavaultplatform.common.model.Restore;
+import org.datavaultplatform.common.model.dao.RestoreDAO;
+
+import java.util.Date;
+import java.util.List;
+
+public class RestoresService {
+
+    private RestoreDAO restoreDAO;
+    
+    public List<Restore> getRestores() {
+        return restoreDAO.list();
+    }
+    
+    public void addRestore(Restore restore, Deposit deposit, String restorePath) {
+        
+        Date d = new Date();
+        restore.setTimestamp(d);
+        
+        restore.setDeposit(deposit);
+        restore.setStatus(Restore.Status.NOT_STARTED);
+        
+        restore.setRestorePath(restorePath);
+        
+        restoreDAO.save(restore);
+    }
+    
+    public void updateRestore(Restore restore) {
+        restoreDAO.update(restore);
+    }
+    
+    public Restore getRestore(String restoreID) {
+        return restoreDAO.findById(restoreID);
+    }
+    
+    public void setRestoreDAO(RestoreDAO restoreDAO) {
+        this.restoreDAO = restoreDAO;
+    }
+
+    public int count() { return restoreDAO.count(); }
+}
+

--- a/datavault-broker/src/main/java/org/datavaultplatform/queue/EventListener.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/queue/EventListener.java
@@ -1,10 +1,7 @@
 package org.datavaultplatform.queue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.datavaultplatform.broker.services.DepositsService;
-import org.datavaultplatform.broker.services.VaultsService;
-import org.datavaultplatform.broker.services.EventService;
-import org.datavaultplatform.broker.services.JobsService;
+import org.datavaultplatform.broker.services.*;
 import org.datavaultplatform.common.event.Event;
 import org.datavaultplatform.common.event.InitStates;
 import org.datavaultplatform.common.event.UpdateState;
@@ -21,6 +18,7 @@ public class EventListener implements MessageListener {
     private EventService eventService;
     private VaultsService vaultsService;
     private DepositsService depositsService;
+    private RestoresService restoresService;
 
     public void setJobsService(JobsService jobsService) {
         this.jobsService = jobsService;
@@ -34,10 +32,12 @@ public class EventListener implements MessageListener {
         this.vaultsService = vaultsService;
     }
     
-    public void setDepositsService(DepositsService depositsService) {
-        this.depositsService = depositsService;
+    public void setDepositsService(DepositsService depositsService) { this.depositsService = depositsService; }
+
+    public void setRestoresService(RestoresService restoresService) {
+        this.restoresService = restoresService;
     }
-    
+
     @Override
     public void onMessage(Message msg) {
         

--- a/datavault-broker/src/main/resources/import.sql
+++ b/datavault-broker/src/main/resources/import.sql
@@ -1,5 +1,12 @@
-insert into Policies (id, name) values ('EPSRC', 'EPSRC retention policy');
-insert into Policies (id, name) values ('POLICY', 'Another policy');
+insert into Policies (id, name, sort) values ('UNIVERSITY', 'Default University Policy', 1);
+insert into Policies (id, name, sort) values ('AHRC', 'AHRC retention policy', 2);
+insert into Policies (id, name, sort) values ('BBSRC', 'BBSRC retention policy', 3);
+insert into Policies (id, name, sort) values ('EPSRC', 'EPSRC retention policy', 4);
+insert into Policies (id, name, sort) values ('ESRC', 'ESRC retention policy', 5);
+insert into Policies (id, name, sort) values ('MRC', 'MRC retention policy', 6);
+insert into Policies (id, name, sort) values ('NERC', 'NERC retention policy', 7);
+insert into Policies (id, name, sort) values ('STFC', 'STFC retention policy', 8);
+insert into Policies (id, name, sort) values ('WELLCOME', 'Wellcome Trust retention policy', 9);
 
 insert into Users (id, name) values ('USER1', 'Test user 1');
 insert into Users (id, name) values ('USER2', 'Test user 2');

--- a/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
@@ -62,6 +62,7 @@
     <bean id="vaultsController" class="org.datavaultplatform.broker.controllers.VaultsController">
         <property name="vaultsService" ref="vaultsService" />
         <property name="depositsService" ref="depositsService" />
+        <property name="restoresService" ref="restoresService" />
         <property name="metadataService" ref="metadataService" />
         <property name="filesService" ref="filesService" />
         <property name="policiesService" ref="policiesService" />
@@ -79,7 +80,7 @@
     <bean id="usersController" class="org.datavaultplatform.broker.controllers.UsersController">
         <property name="usersService" ref="usersService" />
     </bean>
-    
+
     <bean id="fileStoreController" class="org.datavaultplatform.broker.controllers.FileStoreController">
         <property name="usersService" ref="usersService" />
         <property name="fileStoreService" ref="fileStoreService" />
@@ -93,11 +94,15 @@
     <bean id="vaultsService" class="org.datavaultplatform.broker.services.VaultsService">
         <property name="vaultDAO" ref="vaultDAO" />
     </bean>
-    
+
     <bean id="depositsService" class="org.datavaultplatform.broker.services.DepositsService">
         <property name="depositDAO" ref="depositDAO" />
     </bean>
-    
+
+    <bean id="restoresService" class="org.datavaultplatform.broker.services.RestoresService">
+        <property name="restoreDAO" ref="restoreDAO" />
+    </bean>
+
     <bean id="metadataService" class="org.datavaultplatform.broker.services.MetadataService">
         <property name="metaDir" value="${metaDir}"/>
     </bean>
@@ -153,6 +158,7 @@
         <property name="jobsService" ref="jobsService" />
         <property name="vaultsService" ref="vaultsService" />
         <property name="depositsService" ref="depositsService" />
+        <property name="restoresService" ref="restoresService" />
         <property name="eventService" ref="eventService" />
     </bean>
 
@@ -210,7 +216,11 @@
     <bean id="depositDAO" class="org.datavaultplatform.common.model.dao.DepositDAOImpl">
         <property name="sessionFactory" ref="sessionFactory" />
     </bean>
-    
+
+    <bean id="restoreDAO" class="org.datavaultplatform.common.model.dao.RestoreDAOImpl">
+        <property name="sessionFactory" ref="sessionFactory" />
+    </bean>
+
     <bean id="eventDAO" class="org.datavaultplatform.common.model.dao.EventDAOImpl">
         <property name="sessionFactory" ref="sessionFactory" />
     </bean>

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/Deposit.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/Deposit.java
@@ -48,13 +48,19 @@ public class Deposit {
     @OneToMany(targetEntity=Event.class, mappedBy="deposit", fetch=FetchType.LAZY)
     @OrderBy("timestamp, sequence")
     private List<Event> events;
-    
+
     // A Deposit can have a number of active jobs
     @JsonIgnore
     @OneToMany(targetEntity=Job.class, mappedBy="deposit", fetch=FetchType.LAZY)
     @OrderBy("timestamp")
     private List<Job> jobs;
-    
+
+    // A Deposit can have a number of restores
+    @JsonIgnore
+    @OneToMany(targetEntity=Restore.class, mappedBy="deposit", fetch=FetchType.LAZY)
+    @OrderBy("timestamp")
+    private List<Restore> restores;
+
     public enum Status {
         NOT_STARTED,
         IN_PROGRESS,
@@ -154,4 +160,6 @@ public class Deposit {
     public List<Job> getJobs() {
         return jobs;
     }
+
+    public List<Restore> getRestores() { return restores; }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/Policy.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/Policy.java
@@ -19,11 +19,15 @@ public class Policy {
     @Id
     @Column(name = "id", unique = true)
     private String id;
-    
+
     // Name of the policy
     @Column(name = "name", nullable = false)
     private String name;
-    
+
+    // Sort order of the policy
+    @Column(name = "sort", nullable = false)
+    private int sort;
+
     // A policy is related to a number of deposits
     @JsonIgnore
     @OneToMany(targetEntity=Vault.class, mappedBy="policy", fetch=FetchType.LAZY)
@@ -36,10 +40,14 @@ public class Policy {
     }
 
     public String getID() { return id; }
-    
+
     public void setName(String name) {
         this.name = name;
     }
 
     public String getName() { return name; }
+
+    public void setSort(int sort) { this.sort = sort; }
+
+    public int getSort() { return sort; }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/Restore.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/Restore.java
@@ -1,7 +1,56 @@
 package org.datavaultplatform.common.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Entity
+@Table(name="Restores")
 public class Restore {
-    
+
+    // Deposit Identifier
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid2")
+    @Column(name = "id", unique = true)
+    private String id;
+
+    // Serialise date in ISO 8601 format
+    @JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date timestamp;
+
+    @JsonIgnore
+    @ManyToOne
+    private Deposit deposit;
+
+    // A Restore can have a number of events
+    //@JsonIgnore
+    //@OneToMany(targetEntity=Event.class, mappedBy="restore", fetch=FetchType.LAZY)
+    //@OrderBy("timestamp, sequence")
+    //private List<Event> events;
+
+    // A Restore can have a number of active jobs
+    //@JsonIgnore
+    //@OneToMany(targetEntity=Job.class, mappedBy="restore", fetch=FetchType.LAZY)
+    //@OrderBy("timestamp")
+    //private List<Job> jobs;
+
+    public enum Status {
+        NOT_STARTED,
+        IN_PROGRESS,
+        COMPLETE
+    }
+
+    private String note;
+
+    private Status status;
+
     String restorePath;
     
     // Additional properties might go here - e.g. format
@@ -15,4 +64,39 @@ public class Restore {
     public void setRestorePath(String restorePath) {
         this.restorePath = restorePath;
     }
+
+    public void setTimestamp(Date timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public Deposit getDeposit() { return deposit; }
+
+    public void setDeposit(Deposit deposit) {
+        this.deposit = deposit;
+    }
+
+    public String getNote() { return note; }
+
+    public void setNote(String note) {
+        this.note = note;
+    }
+
+    public Status getStatus() { return status; }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+//    public List<Event> getEvents() {
+//        return events;
+//    }
+
+//    public List<Job> getJobs() {
+//        return jobs;
+//    }
+
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/PolicyDAOImpl.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/PolicyDAOImpl.java
@@ -6,6 +6,7 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.Criteria;
+import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Restrictions;
 
 import org.datavaultplatform.common.model.Policy;
@@ -41,6 +42,7 @@ public class PolicyDAOImpl implements PolicyDAO {
     public List<Policy> list() {        
         Session session = this.sessionFactory.openSession();
         Criteria criteria = session.createCriteria(Policy.class);
+        criteria.addOrder(Order.asc("sort"));
         List<Policy> policies = criteria.list();
         session.close();
         return policies;

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RestoreDAO.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RestoreDAO.java
@@ -1,0 +1,18 @@
+package org.datavaultplatform.common.model.dao;
+
+import org.datavaultplatform.common.model.Restore;
+
+import java.util.List;
+
+public interface RestoreDAO {
+
+    public void save(Restore restore);
+    
+    public void update(Restore restore);
+    
+    public List<Restore> list();
+
+    public Restore findById(String Id);
+
+    public int count();
+}

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RestoreDAOImpl.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RestoreDAOImpl.java
@@ -1,0 +1,67 @@
+package org.datavaultplatform.common.model.dao;
+
+import org.datavaultplatform.common.model.Restore;
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.criterion.Order;
+import org.hibernate.criterion.Projections;
+import org.hibernate.criterion.Restrictions;
+
+import java.util.List;
+
+public class RestoreDAOImpl implements RestoreDAO {
+
+    private SessionFactory sessionFactory;
+ 
+    public void setSessionFactory(SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+     
+    @Override
+    public void save(Restore restore) {
+        Session session = this.sessionFactory.openSession();
+        Transaction tx = session.beginTransaction();
+        session.persist(restore);
+        tx.commit();
+        session.close();
+    }
+ 
+    @Override
+    public void update(Restore restore) {
+        Session session = this.sessionFactory.openSession();
+        Transaction tx = session.beginTransaction();
+        session.update(restore);
+        tx.commit();
+        session.close();
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<Restore> list() {
+        Session session = this.sessionFactory.openSession();
+        Criteria criteria = session.createCriteria(Restore.class);
+        criteria.setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY);
+        criteria.addOrder(Order.asc("creationTime"));
+        List<Restore> restores = criteria.list();
+        session.close();
+        return restores;
+    }
+    
+    @Override
+    public Restore findById(String Id) {
+        Session session = this.sessionFactory.openSession();
+        Criteria criteria = session.createCriteria(Restore.class);
+        criteria.add(Restrictions.eq("id", Id));
+        Restore restore = (Restore)criteria.uniqueResult();
+        session.close();
+        return restore;
+    }
+
+    @Override
+    public int count() {
+        Session session = this.sessionFactory.openSession();
+        return (int)(long)(Long)session.createCriteria(Restore.class).setProjection(Projections.rowCount()).uniqueResult();
+    }
+}

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/DepositsController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/DepositsController.java
@@ -54,6 +54,7 @@ public class DepositsController {
         model.addAttribute("deposit", restService.getDeposit(vaultID, depositID));
         model.addAttribute("manifest", restService.getDepositManifest(vaultID, depositID));
         model.addAttribute("events", restService.getDepositEvents(vaultID, depositID));
+        model.addAttribute("restores", restService.getDepositRestores(vaultID, depositID));
         return "deposits/deposit";
     }
     

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/VaultsController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/VaultsController.java
@@ -52,11 +52,7 @@ public class VaultsController {
         model.addAttribute("vault", new Vault());
 
         Policy[] policies = restService.getPolicyListing();
-        Map<String, String> policyMap = new HashMap<>();
-        for (Policy policy : policies) {
-            policyMap.put(policy.getID(), policy.getName());
-        }
-        model.addAttribute("policyMap", policyMap);
+        model.addAttribute("policies", policies);
 
         return "vaults/create";
     }

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminController.java
@@ -31,6 +31,7 @@ public class AdminController {
         model.addAttribute("usercount", restService.getUsersCount());
         model.addAttribute("vaultcount", restService.getVaultsCount());
         model.addAttribute("depositcount", restService.getDepositsCount());
+        model.addAttribute("restorecount", restService.getRestoresCount());
         Long vaultSize = restService.getVaultsSize();
         if (vaultSize == null) vaultSize = new Long(0);
         model.addAttribute("vaultsize", FileUtils.byteCountToDisplaySize(vaultSize));

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/RestService.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/RestService.java
@@ -91,6 +91,11 @@ public class RestService {
         return (Integer)response.getBody();
     }
 
+    public int getRestoresCount() {
+        HttpEntity<?> response = get(brokerURL + "/vaults/restorecount", Integer.class);
+        return (Integer)response.getBody();
+    }
+
     public Vault getVault(String id) {        
         HttpEntity<?> response = get(brokerURL + "/vaults/" + id, Vault.class);
         return (Vault)response.getBody();
@@ -121,10 +126,15 @@ public class RestService {
         HttpEntity<?> response = get(brokerURL + "/vaults/" + vaultId + "/deposits/" + depositID + "/events", Event[].class);
         return (Event[])response.getBody();
     }
-    
+
     public Job[] getDepositJobs(String vaultId, String depositID) {
         HttpEntity<?> response = get(brokerURL + "/vaults/" + vaultId + "/deposits/" + depositID + "/jobs", Job[].class);
         return (Job[])response.getBody();
+    }
+
+    public Restore[] getDepositRestores(String vaultId, String depositID) {
+        HttpEntity<?> response = get(brokerURL + "/vaults/" + vaultId + "/deposits/" + depositID + "/restores", Restore[].class);
+        return (Restore[])response.getBody();
     }
 
     public Policy[] getPolicyListing() {

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/index.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/index.ftl
@@ -4,14 +4,22 @@
 
     <div class="row">
         <div class="col-xs-6 col-md-4">
-            <div class="panel panel-primary">
+            <div class="panel panel-warning">
+                <div class="panel-heading">
+                    <h3 class="panel-title glyphicon glyphicon-dashboard"> Size</h3>
+                </div>
+                <div class="panel-body">
+                    <h4>Vault size: ${vaultsize}</h4>
+                </div>
+            </div>
+        </div>
+        <div class="col-xs-6 col-md-4">
+            <div class="panel panel-info">
                 <div class="panel-heading">
                     <h3 class="panel-title glyphicon glyphicon-user"> Users</h3>
                 </div>
                 <div class="panel-body">
-                    <ul>
-                        <li>Users: <a href="${springMacroRequestContext.getContextPath()}/admin/users">${usercount}</a></li>
-                    </ul>
+                    <h4>Users: <a href="${springMacroRequestContext.getContextPath()}/admin/users">${usercount}</a></h4>
                 </div>
             </div>
         </div>
@@ -21,21 +29,7 @@
                     <h3 class="panel-title glyphicon glyphicon-dashboard"> Vaults</h3>
                 </div>
                 <div class="panel-body">
-                    <ul>
-                        <li>Vaults: <a href="${springMacroRequestContext.getContextPath()}/admin/vaults">${vaultcount}</a></li>
-                    </ul>
-                </div>
-            </div>
-        </div>
-        <div class="col-xs-6 col-md-4">
-            <div class="panel panel-info">
-                <div class="panel-heading">
-                    <h3 class="panel-title glyphicon glyphicon-save"> Deposits</h3>
-                </div>
-                <div class="panel-body">
-                    <ul>
-                        <li>Deposits: <a href="${springMacroRequestContext.getContextPath()}/admin/deposits">${depositcount}</a></li>
-                    </ul>
+                    <h4>Vaults: <a href="${springMacroRequestContext.getContextPath()}/admin/vaults">${vaultcount}</a></h4>
                 </div>
             </div>
         </div>
@@ -43,18 +37,25 @@
 
     <div class="row">
         <div class="col-xs-6 col-md-4">
-            <div class="panel panel-warning">
+            <div class="panel panel-info">
                 <div class="panel-heading">
-                    <h3 class="panel-title glyphicon glyphicon-dashboard"> Size</h3>
+                    <h3 class="panel-title glyphicon glyphicon-save"> Deposits</h3>
                 </div>
                 <div class="panel-body">
-                    <ul>
-                        <li>Vault size: ${vaultsize}</li>
-                    </ul>
+                    <h4>Deposits: <a href="${springMacroRequestContext.getContextPath()}/admin/deposits">${depositcount}</a></h4>
                 </div>
             </div>
         </div>
-        <div class="col-xs-6 col-md-4"></div>
+        <div class="col-xs-6 col-md-4">
+            <div class="panel panel-success">
+                <div class="panel-heading">
+                    <h3 class="panel-title glyphicon glyphicon-open"> Restores</h3>
+                </div>
+                <div class="panel-body">
+                    <h4>Restores: ${restorecount}</h4>
+                </div>
+            </div>
+        </div>
         <div class="col-xs-6 col-md-4"></div>
     </div>
 

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/deposit.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/deposit.ftl
@@ -24,6 +24,7 @@
         <li class="active"><a data-toggle="tab" href="#deposit">Deposit</a></li>
         <li><a data-toggle="tab" href="#contents">Contents <span class="badge">${manifest?size}</span></a></li>
         <li><a data-toggle="tab" href="#events">Events <span class="badge">${events?size}</span></a></li>
+        <li><a data-toggle="tab" href="#restores">Restores <span class="badge">${restores?size}</span></a></li>
     </ul>
 
     <div id="deposit-tab-content" class="tab-content">
@@ -88,6 +89,29 @@
                             <td>${event.eventClass?html}</td>
                             <td>${event.message?html}</td>
                             <td>${event.timestamp?datetime}</td>
+                        </tr>
+                        </#list>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="tab-pane" id="restores">
+            <div class="table-responsive">
+                <table class="table table-striped">
+                    <thead>
+                    <tr class="tr">
+                        <th>Timestamp</th>
+                        <th>Restore path</th>
+                        <th>Restore note</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                        <#list restores as restore>
+                        <tr class="tr">
+                            <td>${restore.timestamp?datetime}</td>
+                            <td>${restore.restorePath?html}</td>
+                            <td>${restore.note?html}</td>
                         </tr>
                         </#list>
                     </tbody>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/deposit.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/deposit.ftl
@@ -96,7 +96,7 @@
         </div>
     </div>
 
-    <a class="btn btn-primary" href="${springMacroRequestContext.getContextPath()}/vaults/${vault.getID()}/deposits/${deposit.getID()}/restore">
+    <a id="restorebtn" class="btn btn-primary" href="${springMacroRequestContext.getContextPath()}/vaults/${vault.getID()}/deposits/${deposit.getID()}/restore">
         <span class="glyphicon glyphicon-open" aria-hidden="true"></span> Restore data
     </a>
 
@@ -152,11 +152,13 @@
                 <!-- a pending job -->
                 updateInterval = 500;
                 $('#progtrckr').hide()
+                $('#restorebtn').hide()
                 
             } else if (job.state != job.states.length - 1) {
                 <!-- an active job -->
                 updateInterval = 500;
                 $('#progtrckr').show()
+                $('#restorebtn').hide()
                 displayJob(job)
                 
             } else {

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/restore.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/restore.ftl
@@ -10,9 +10,19 @@
         <li class="active">Restore data</li>
     </ol>
 
-    <p class="help-block">Choose a working directory to restore data from the archive</p>
+    <p class="help-block">Desribe the reason for this restore request (who and why) and choose a working directory to restore data from the archive</p>
 
     <form class="form" role="form" action="" method="post">
+
+        <div class="form-group">
+            <label class="control-label">Restore Note:</label>
+            <@spring.bind "restore.note" />
+            <input type="text"
+                   class="form-control"
+                   name="${spring.status.expression}"
+                   value="${spring.status.value!""}"/>
+        </div>
+
 
         <div class="form-group" style="display:none;">
             <label class="control-label">Filepath:</label>
@@ -58,14 +68,10 @@
 
         <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 
-        <div class="pull-left">
+        <div class="form-group">
             <button type="submit" name="action" value="submit" class="btn btn-primary"><span class="glyphicon glyphicon-open"></span> Restore data</button>
-        </div>
-
-        <div class="pull-right">
             <button type="submit" name="action" value="cancel" class="btn btn-danger cancel">Cancel</button>
         </div>
-
 
     </form>
 

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/create.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/create.ftl
@@ -30,8 +30,11 @@
 
         <div class="form-group">
             <label class="control-label">Policy:</label>
-            <@spring.bind "policyMap" />
-            <@spring.formSingleSelect "vault.policyID", policyMap, "class='policy-select'" />
+            <select id="policyID" name="policyID" class='policy-select'>
+                <#list policies as policy>
+                    <option value="${policy.getID()}">${policy.name?html}</option>
+                </#list>
+            </select>
         </div>
 
         <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Deposit.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Deposit.java
@@ -6,7 +6,6 @@ import java.lang.reflect.Constructor;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashMap;
 
 import org.datavaultplatform.common.task.Context;
 import org.datavaultplatform.common.task.Task;


### PR DESCRIPTION
This pull request creates a new Restore object in the broker's database.  A Deposit can have many Restores, a Restore has one Deposit.

When a deposit request is made, a note is required (like a deposit note) to record why the restore request is being made.

A count of the restores and the details is available via a new tab on the deposit screen.

Note: I've also tweaked the javascript on the progress bar to remove the 'Restore' button from 'IN_PROGRESS' deposits, as you shouldn't (can't?) restore a deposit until it is complete.  However it flashes up momentarily - not sure if there is a better mechanism to achieve this?