### PR TITLE
New admin metric to show queue lengths

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/VaultsController.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/VaultsController.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @RestController
 @Api(name="Vaults", description = "Interact with DataVault Vaults")
 public class VaultsController {
-    
+
     private VaultsService vaultsService;
     private DepositsService depositsService;
     private RestoresService restoresService;
@@ -30,38 +30,38 @@ public class VaultsController {
     private FileStoreService fileStoreService;
     private JobsService jobsService;
     private Sender sender;
-    
+
     private String activeDir;
-    
+
     // Get the specified Vault object and validate it against the current User
     private Vault getUserVault(User user, String vaultID) throws Exception {
-        
+
         Vault vault = vaultsService.getVault(vaultID);
-        
+
         if (vault == null) {
             throw new Exception("Vault '" + vaultID + "' does not exist");
         }
-        
+
         if (!vault.getUser().equals(user)) {
             throw new Exception("Access denied");
         }
-        
+
         return vault;
     }
-    
+
     // Get the specified Deposit object and validate it against the current User and Vault
     private Deposit getUserDeposit(User user, String vaultID, String depositID) throws Exception {
-        
+
         Vault vault = getUserVault(user, vaultID);
         Deposit deposit = depositsService.getDeposit(depositID);
-        
+
         if (!vault.equals(deposit.getVault())) {
             throw new Exception("Invalid Vault ID");
         }
-        
+
         return deposit;
     }
-    
+
     public void setVaultsService(VaultsService vaultsService) {
         this.vaultsService = vaultsService;
     }
@@ -77,11 +77,11 @@ public class VaultsController {
     public void setMetadataService(MetadataService metadataService) {
         this.metadataService = metadataService;
     }
-    
+
     public void setFilesService(FilesService filesService) {
         this.filesService = filesService;
     }
-    
+
     public void setPoliciesService(PoliciesService policiesService) {
         this.policiesService = policiesService;
     }
@@ -89,7 +89,7 @@ public class VaultsController {
     public void setFileStoreService(FileStoreService fileStoreService) {
         this.fileStoreService = fileStoreService;
     }
-    
+
     public void setUsersService(UsersService usersService) {
         this.usersService = usersService;
     }
@@ -97,11 +97,11 @@ public class VaultsController {
     public void setJobsService(JobsService jobsService) {
         this.jobsService = jobsService;
     }
-    
+
     public void setSender(Sender sender) {
         this.sender = sender;
     }
-    
+
     // NOTE: this a placeholder and will eventually be handled by per-user config
     public void setActiveDir(String activeDir) {
         this.activeDir = activeDir;
@@ -145,6 +145,7 @@ public class VaultsController {
             return vaultsService.getVaults(sort);
         }
     }
+
     @RequestMapping(value = "/vaults/search", method = RequestMethod.GET)
     public List<Vault> searchAllVaults(@RequestHeader(value = "X-UserID", required = true) String userID,
                                        @RequestParam String query,
@@ -179,10 +180,22 @@ public class VaultsController {
         return depositsService.count();
     }
 
+    @RequestMapping(value = "/vaults/depositqueuecount", method = RequestMethod.GET)
+    public int getDepositsQueueCount(@RequestHeader(value = "X-UserID", required = true) String userID) throws Exception {
+
+        return depositsService.queueCount();
+    }
+
     @RequestMapping(value = "/vaults/restorecount", method = RequestMethod.GET)
     public int getRestoresCount(@RequestHeader(value = "X-UserID", required = true) String userID) throws Exception {
 
         return restoresService.count();
+    }
+
+    @RequestMapping(value = "/vaults/restorequeuecount", method = RequestMethod.GET)
+    public int getRestoresQueuedCount(@RequestHeader(value = "X-UserID", required = true) String userID) throws Exception {
+
+        return restoresService.queueCount();
     }
 
     @RequestMapping(value = "/vaults/deposits", method = RequestMethod.GET)
@@ -201,20 +214,20 @@ public class VaultsController {
     @RequestMapping(value = "/vaults", method = RequestMethod.POST)
     public Vault addVault(@RequestHeader(value = "X-UserID", required = true) String userID,
                           @RequestBody Vault vault) throws Exception {
-        
+
         String policyID = vault.getPolicyID();
         Policy policy = policiesService.getPolicy(policyID);
         if (policy == null) {
             throw new Exception("Policy '" + policyID + "' does not exist");
         }
         vault.setPolicy(policy);
-        
+
         User user = usersService.getUser(userID);
         if (user == null) {
             throw new Exception("User '" + userID + "' does not exist");
         }
         vault.setUser(user);
-        
+
         // For testing purposes add a default file store for the user if none exists.
         // This is an action that will ideally take place at user creation instead.
         // A template could be used to construct file paths (if configured).
@@ -226,7 +239,7 @@ public class VaultsController {
             store.setUser(user);
             fileStoreService.addFileStore(store);
         }
-        
+
         vaultsService.addVault(vault);
         return vault;
     }
@@ -238,17 +251,17 @@ public class VaultsController {
         User user = usersService.getUser(userID);
         return getUserVault(user, vaultID);
     }
-    
+
     @RequestMapping(value = "/vaults/{vaultid}/deposits", method = RequestMethod.GET)
     public List<Deposit> getDeposits(@RequestHeader(value = "X-UserID", required = true) String userID,
                                      @PathVariable("vaultid") String vaultID) throws Exception {
-        
+
         User user = usersService.getUser(userID);
         Vault vault = getUserVault(user, vaultID);
-        
+
         return vault.getDeposits();
     }
-    
+
     @RequestMapping(value = "/vaults/{vaultid}/deposits", method = RequestMethod.POST)
     public Deposit addDeposit(@RequestHeader(value = "X-UserID", required = true) String userID,
                               @PathVariable("vaultid") String vaultID,
@@ -256,7 +269,7 @@ public class VaultsController {
 
         User user = usersService.getUser(userID);
         Vault vault = getUserVault(user, vaultID);
-        
+
         String fullPath = deposit.getFilePath();
         String storageID, storagePath;
         if (!fullPath.contains("/")) {
@@ -268,7 +281,7 @@ public class VaultsController {
             storageID = fullPath.substring(0, fullPath.indexOf("/"));
             storagePath = fullPath.replaceFirst(storageID + "/", "");
         }
-        
+
         FileStore store = null;
         List<FileStore> userStores = user.getFileStores();
         for (FileStore userStore : userStores) {
@@ -276,23 +289,23 @@ public class VaultsController {
                 store = userStore;
             }
         }
-        
+
         if (store == null) {
             throw new IllegalArgumentException("Storage ID '" + storageID + "' is invalid");
         }
-        
+
         // Check the source file path is valid
         if (!filesService.validPath(storagePath, store)) {
             throw new IllegalArgumentException("Path '" + storagePath + "' is invalid");
         }
-        
+
         // Add the deposit object
         depositsService.addDeposit(vault, deposit, storagePath, store.getLabel());
-        
+
         // Create a job to track this deposit
         Job job = new Job("org.datavaultplatform.worker.tasks.Deposit");
         jobsService.addJob(deposit, job);
-        
+
         // Ask the worker to process the deposit
         try {
             ObjectMapper mapper = new ObjectMapper();
@@ -301,41 +314,41 @@ public class VaultsController {
             depositProperties.put("depositId", deposit.getID());
             depositProperties.put("bagId", deposit.getBagId());
             depositProperties.put("filePath", storagePath); // Path without storage ID
-            
+
             // Deposit and Vault metadata
             // TODO: at the moment we're just serialising the objects to JSON.
             // In future we'll need a more formal schema/representation (e.g. RDF or JSON-LD).
             depositProperties.put("depositMetadata", mapper.writeValueAsString(deposit));
             depositProperties.put("vaultMetadata", mapper.writeValueAsString(vault));
-            
+
             Task depositTask = new Task(job, depositProperties, store);
             String jsonDeposit = mapper.writeValueAsString(depositTask);
             sender.send(jsonDeposit);
-            
+
         } catch (Exception e) {
             e.printStackTrace();
         }
-        
+
         return deposit;
     }
-    
+
     @RequestMapping(value = "/vaults/{vaultid}/deposits/{depositid}", method = RequestMethod.GET)
-    public Deposit getDeposit(@RequestHeader(value = "X-UserID", required = true) String userID, 
+    public Deposit getDeposit(@RequestHeader(value = "X-UserID", required = true) String userID,
                               @PathVariable("vaultid") String vaultID,
                               @PathVariable("depositid") String depositID) throws Exception {
-        
+
         User user = usersService.getUser(userID);
         return getUserDeposit(user, vaultID, depositID);
     }
-    
+
     @RequestMapping(value = "/vaults/{vaultid}/deposits/{depositid}/manifest", method = RequestMethod.GET)
-    public List<FileFixity> getDepositManifest(@RequestHeader(value = "X-UserID", required = true) String userID, 
+    public List<FileFixity> getDepositManifest(@RequestHeader(value = "X-UserID", required = true) String userID,
                                                @PathVariable("vaultid") String vaultID,
                                                @PathVariable("depositid") String depositID) throws Exception {
-        
+
         User user = usersService.getUser(userID);
         Deposit deposit = getUserDeposit(user, vaultID, depositID);
-        
+
         List<FileFixity> manifest = metadataService.getManifest(deposit.getBagId());
         return manifest;
     }
@@ -365,63 +378,63 @@ public class VaultsController {
     }
 
     @RequestMapping(value = "/vaults/{vaultid}/deposits/{depositid}/jobs", method = RequestMethod.GET)
-    public List<Job> getDepositJobs(@RequestHeader(value = "X-UserID", required = true) String userID, 
+    public List<Job> getDepositJobs(@RequestHeader(value = "X-UserID", required = true) String userID,
                                     @PathVariable("vaultid") String vaultID,
                                     @PathVariable("depositid") String depositID) throws Exception {
 
         User user = usersService.getUser(userID);
         Deposit deposit = getUserDeposit(user, vaultID, depositID);
-        
+
         List<Job> jobs = deposit.getJobs();
         return jobs;
     }
 
     @RequestMapping(value = "/vaults/{vaultid}/deposits/{depositid}/status", method = RequestMethod.GET)
-    public Deposit.Status getDepositState(@RequestHeader(value = "X-UserID", required = true) String userID, 
+    public Deposit.Status getDepositState(@RequestHeader(value = "X-UserID", required = true) String userID,
                                           @PathVariable("vaultid") String vaultID,
                                           @PathVariable("depositid") String depositID) throws Exception {
-        
+
         User user = usersService.getUser(userID);
         Deposit deposit = getUserDeposit(user, vaultID, depositID);
-        
+
         return deposit.getStatus();
     }
-    
+
     @RequestMapping(value = "/vaults/{vaultid}/deposits/{depositid}/status", method = RequestMethod.POST)
-    public Deposit setDepositState(@RequestHeader(value = "X-UserID", required = true) String userID, 
+    public Deposit setDepositState(@RequestHeader(value = "X-UserID", required = true) String userID,
                                    @PathVariable("vaultid") String vaultID,
                                    @PathVariable("depositid") String depositID,
                                    @RequestBody Deposit.Status status) throws Exception {
 
         User user = usersService.getUser(userID);
         Deposit deposit = getUserDeposit(user, vaultID, depositID);
-        
+
         deposit.setStatus(status);
         depositsService.updateDeposit(deposit);
         return deposit;
     }
-    
+
     @RequestMapping(value = "/vaults/{vaultid}/deposits/{depositid}/restore", method = RequestMethod.POST)
-    public Boolean restoreDeposit(@RequestHeader(value = "X-UserID", required = true) String userID, 
+    public Boolean restoreDeposit(@RequestHeader(value = "X-UserID", required = true) String userID,
                                   @PathVariable("vaultid") String vaultID,
                                   @PathVariable("depositid") String depositID,
                                   @RequestBody Restore restore) throws Exception {
-        
+
         User user = usersService.getUser(userID);
         Deposit deposit = getUserDeposit(user, vaultID, depositID);
-        
+
         String fullPath = restore.getRestorePath();
         String storageID, restorePath;
         if (!fullPath.contains("/")) {
-            // A request to archive the whole share/device
+            // A request to restore the whole share/device
             storageID = fullPath;
             restorePath = "/";
         } else {
-            // A request to archive a sub-directory
+            // A request to restore a sub-directory
             storageID = fullPath.substring(0, fullPath.indexOf("/"));
             restorePath = fullPath.replaceFirst(storageID + "/", "");
         }
-        
+
         FileStore store = null;
         List<FileStore> userStores = user.getFileStores();
         for (FileStore userStore : userStores) {
@@ -429,21 +442,21 @@ public class VaultsController {
                 store = userStore;
             }
         }
-        
+
         if (store == null) {
             throw new IllegalArgumentException("Storage ID '" + storageID + "' is invalid");
         }
-        
+
         // Validate the path
         if (restorePath == null) {
             throw new IllegalArgumentException("Path was null");
         }
-        
+
         // Check the source file path is valid
         if (!filesService.validPath(restorePath, store)) {
             throw new IllegalArgumentException("Path '" + restorePath + "' is invalid");
         }
-        
+
         // Create a job to track this restore
         Job job = new Job("org.datavaultplatform.worker.tasks.Restore");
         jobsService.addJob(deposit, job);
@@ -457,7 +470,7 @@ public class VaultsController {
             restoreProperties.put("depositId", deposit.getID());
             restoreProperties.put("bagId", deposit.getBagId());
             restoreProperties.put("restorePath", restorePath); // No longer the absolute path
-            
+
             Task restoreTask = new Task(job, restoreProperties, store);
             ObjectMapper mapper = new ObjectMapper();
             String jsonRestore = mapper.writeValueAsString(restoreTask);
@@ -465,7 +478,7 @@ public class VaultsController {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        
+
         return true;
     }
 }

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/DepositsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/DepositsService.java
@@ -48,6 +48,8 @@ public class DepositsService {
 
     public int count() { return depositDAO.count(); }
 
+    public int queueCount() { return depositDAO.queueCount(); }
+
     public List<Deposit> search(String query, String sort) { return this.depositDAO.search(query, sort); }
 
     public Long size() { return depositDAO.size(); }

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/RestoresService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/RestoresService.java
@@ -41,5 +41,7 @@ public class RestoresService {
     }
 
     public int count() { return restoreDAO.count(); }
+
+    public int queueCount() { return restoreDAO.queueCount(); }
 }
 

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/VaultsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/VaultsService.java
@@ -34,8 +34,6 @@ public class VaultsService {
 
     public List<Vault> search(String query, String sort) { return this.vaultDAO.search(query, sort); }
 
-    public int count() {
-        return vaultDAO.count();
-    }
+    public int count() { return vaultDAO.count(); }
 }
 

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/Deposit.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/Deposit.java
@@ -44,27 +44,23 @@ public class Deposit {
     @Temporal(TemporalType.TIMESTAMP)
     private Date creationTime;
 
-    @ApiObjectField(description = "Vault that this Deposit belongs to")
     @JsonIgnore
     @ManyToOne
     private Vault vault;
     
     // A Deposit can have a number of events
-    @ApiObjectField(description = "Events that have taken place to this Deposit")
     @JsonIgnore
     @OneToMany(targetEntity=Event.class, mappedBy="deposit", fetch=FetchType.LAZY)
     @OrderBy("timestamp, sequence")
     private List<Event> events;
 
     // A Deposit can have a number of active jobs
-    @ApiObjectField(description = "Jobs related to this Deposit")
     @JsonIgnore
     @OneToMany(targetEntity=Job.class, mappedBy="deposit", fetch=FetchType.LAZY)
     @OrderBy("timestamp")
     private List<Job> jobs;
 
     // A Deposit can have a number of restores
-    @ApiObjectField(description = "Restores of this Deposit")
     @JsonIgnore
     @OneToMany(targetEntity=Restore.class, mappedBy="deposit", fetch=FetchType.LAZY)
     @OrderBy("timestamp")
@@ -86,11 +82,15 @@ public class Deposit {
     private String bagId;
     
     // Record the file path that the user selected for this deposit.
+    @ApiObjectField(description = "Origin of the deposited filepath")
     private String fileOrigin;
+    @ApiObjectField(description = "Short version of the origin of the deposited filepath")
     private String shortFilePath;
+    @ApiObjectField(description = "Filepath of the origin deposit")
     private String filePath;
     
     // Size of the deposit (in bytes)
+    @ApiObjectField(description = "Size of the depoit (in bytes)")
     private long depositSize;
     
     public Deposit() {}

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/DepositDAO.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/DepositDAO.java
@@ -15,6 +15,8 @@ public interface DepositDAO {
 
     public int count();
 
+    public int queueCount();
+
     public List<Deposit> search(String query, String sort);
 
     public Long size();

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/DepositDAOImpl.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/DepositDAOImpl.java
@@ -80,6 +80,15 @@ public class DepositDAOImpl implements DepositDAO {
     }
 
     @Override
+    public int queueCount() {
+        Session session = this.sessionFactory.openSession();
+        Criteria criteria = session.createCriteria(Deposit.class);
+        criteria.add(Restrictions.eq("status", Deposit.Status.NOT_STARTED));
+        criteria.setProjection(Projections.rowCount());
+        return (int)(long)(Long)criteria.uniqueResult();
+    }
+
+    @Override
     public List<Deposit> search(String query, String sort) {
         Session session = this.sessionFactory.openSession();
         Criteria criteria = session.createCriteria(Deposit.class);

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RestoreDAO.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RestoreDAO.java
@@ -15,4 +15,6 @@ public interface RestoreDAO {
     public Restore findById(String Id);
 
     public int count();
+
+    public int queueCount();
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RestoreDAOImpl.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RestoreDAOImpl.java
@@ -14,11 +14,11 @@ import java.util.List;
 public class RestoreDAOImpl implements RestoreDAO {
 
     private SessionFactory sessionFactory;
- 
+
     public void setSessionFactory(SessionFactory sessionFactory) {
         this.sessionFactory = sessionFactory;
     }
-     
+
     @Override
     public void save(Restore restore) {
         Session session = this.sessionFactory.openSession();
@@ -27,7 +27,7 @@ public class RestoreDAOImpl implements RestoreDAO {
         tx.commit();
         session.close();
     }
- 
+
     @Override
     public void update(Restore restore) {
         Session session = this.sessionFactory.openSession();
@@ -36,7 +36,7 @@ public class RestoreDAOImpl implements RestoreDAO {
         tx.commit();
         session.close();
     }
-    
+
     @SuppressWarnings("unchecked")
     @Override
     public List<Restore> list() {
@@ -48,13 +48,13 @@ public class RestoreDAOImpl implements RestoreDAO {
         session.close();
         return restores;
     }
-    
+
     @Override
     public Restore findById(String Id) {
         Session session = this.sessionFactory.openSession();
         Criteria criteria = session.createCriteria(Restore.class);
         criteria.add(Restrictions.eq("id", Id));
-        Restore restore = (Restore)criteria.uniqueResult();
+        Restore restore = (Restore) criteria.uniqueResult();
         session.close();
         return restore;
     }
@@ -62,6 +62,15 @@ public class RestoreDAOImpl implements RestoreDAO {
     @Override
     public int count() {
         Session session = this.sessionFactory.openSession();
-        return (int)(long)(Long)session.createCriteria(Restore.class).setProjection(Projections.rowCount()).uniqueResult();
+        return (int) (long) (Long) session.createCriteria(Restore.class).setProjection(Projections.rowCount()).uniqueResult();
+    }
+
+    @Override
+    public int queueCount() {
+        Session session = this.sessionFactory.openSession();
+        Criteria criteria = session.createCriteria(Restore.class);
+        criteria.add(Restrictions.eq("status", Restore.Status.NOT_STARTED));
+        criteria.setProjection(Projections.rowCount());
+        return (int)(long)(Long)criteria.uniqueResult();
     }
 }

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminController.java
@@ -35,6 +35,8 @@ public class AdminController {
         Long vaultSize = restService.getVaultsSize();
         if (vaultSize == null) vaultSize = new Long(0);
         model.addAttribute("vaultsize", FileUtils.byteCountToDisplaySize(vaultSize));
+        model.addAttribute(("depositqueue"), restService.getDepositsQueue());
+        model.addAttribute(("restorequeue"), restService.getRestoresQueue());
 
         return "admin/index";
     }

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/RestService.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/RestService.java
@@ -106,6 +106,11 @@ public class RestService {
         return (Integer)response.getBody();
     }
 
+    public int getDepositsQueue() {
+        HttpEntity<?> response = get(brokerURL + "/vaults/depositqueuecount", Integer.class);
+        return (Integer)response.getBody();
+    }
+
     public Deposit[] searchDeposits(String query) {
         HttpEntity<?> response = get(brokerURL + "/vaults/deposits/search?query=" + query, Deposit[].class);
         return (Deposit[])response.getBody();
@@ -118,6 +123,11 @@ public class RestService {
 
     public int getRestoresCount() {
         HttpEntity<?> response = get(brokerURL + "/vaults/restorecount", Integer.class);
+        return (Integer)response.getBody();
+    }
+
+    public int getRestoresQueue() {
+        HttpEntity<?> response = get(brokerURL + "/vaults/restorequeuecount", Integer.class);
         return (Integer)response.getBody();
     }
 

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/index.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/index.ftl
@@ -56,7 +56,16 @@
                 </div>
             </div>
         </div>
-        <div class="col-xs-6 col-md-4"></div>
+        <div class="col-xs-6 col-md-4">
+            <div class="panel panel-warning">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Deposit / Restore Queues</h3>
+                </div>
+                <div class="panel-body">
+                    <h1 class="text-center"><a href="#"><span class="glyphicon glyphicon-arrow-down"></span> ${depositqueue}</a> <a href="#"><span class="glyphicon glyphicon-arrow-up"></span> ${restorequeue}</a></h1>
+                </div>
+            </div>
+        </div>
     </div>
 
 


### PR DESCRIPTION
N.B. - Restores not working, as it calculates queue length by looking for NOT_STARTED status on deposits and restores.  See issue: #171 

(this needn't stop this pull request being accepted as the functionality will start working once the issue is fixed).

Fixes #122 (although it doesn't query rabbit for this number).