### PR TITLE
Untar, validate and restore bag contents

### DIFF
--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/Packager.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/Packager.java
@@ -36,6 +36,22 @@ public class Packager {
         return result;
     }
     
+    // Validate an existing bag
+    public static boolean validateBag(File dir) throws Exception {
+
+        BagFactory bagFactory = new BagFactory();
+        Bag bag = bagFactory.createBag(dir);
+        
+        boolean result = false;
+        try {
+            result = bag.verifyValid().isSuccess();
+        } finally {
+            bag.close();
+        }
+        
+        return result;
+    }
+    
     // Add vault/deposit metadata
     public static boolean addMetadata(File bagDir, String depositMetadata, String vaultMetadata) {
         


### PR DESCRIPTION
Also fixes SFTP/Dropbox file store code to allow restoring directories rather than just single files.

At the moment the exploded bagit structure is restored to a new directory under the user's chosen path (directory name is the bag UUID).