### PR TITLE
Rename "getId" to "getID" in User model

### DIFF
--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/Group.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/Group.java
@@ -72,7 +72,7 @@ public class Group {
 
     public boolean hasMember(String userID) {
         for (User user : owners) {
-            if (user.getId().equals(userID)) return true;
+            if (user.getID().equals(userID)) return true;
         }
         return false;
     }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/User.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/User.java
@@ -34,11 +34,11 @@ public class User {
         this.name = name;
     }
 
-    public void setId(String id) {
+    public void setID(String id) {
         this.id = id;
     }
 
-    public String getId() { return id; }
+    public String getID() { return id; }
     
     public void setName(String name) {
         this.name = name;
@@ -65,7 +65,7 @@ public class User {
         
         final User user = (User)other;
         
-        if (!user.getId().equals(getId())) {
+        if (!user.getID().equals(getID())) {
             return false;
         }
         
@@ -74,6 +74,6 @@ public class User {
     
     @Override
     public int hashCode() {
-        return getId().hashCode();
+        return getID().hashCode();
     }
 }

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/groups/index.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/groups/index.ftl
@@ -30,7 +30,7 @@
                             <td>
                                 <ul class="list-group">
                                     <#list group.getOwners() as user>
-                                        <li class="list-group-item"><span class="glyphicon glyphicon-user" aria-hidden="true"></span> ${user.name?html} (${user.ID?html})</li>
+                                        <li class="list-group-item"><span class="glyphicon glyphicon-user" aria-hidden="true"></span> ${user.name?html} (${user.getID()?html})</li>
                                    </#list>
                                 </ul>
                             </td>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/groups/index.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/groups/index.ftl
@@ -33,11 +33,11 @@
                             <tbody>
                                 <#list vaults[counter] as vault>
                                     <tr class="tr">
-                                        <td>${vault.getID()}</td>
+                                        <td>${vault.getID()?html}</td>
                                         <td>${vault.name?html}</td>
                                         <td>${vault.description?html}</td>
-                                        <td>${vault.getUser().getId()?html}</td>
-                                        <td>${vault.getSizeStr()}</td>
+                                        <td>${vault.getUser().getID()?html}</td>
+                                        <td>${vault.getSizeStr()?html}</td>
                                         <td>${vault.policyID?html}</td>
                                         <td>${vault.getCreationTime()?datetime}</td>
                                     </tr>


### PR DESCRIPTION
Consistent with other models. Also resolves an error on the admin/groups page.

Perhaps we need some naming conventions for common attributes such as "ID" / "Id" / "id".

Following changes in #188.