### PR TITLE
Update admin users screen with change to API

### DIFF
--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/users/index.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/users/index.ftl
@@ -21,7 +21,7 @@
                 <tbody>
                     <#list users as user>
                         <tr class="tr">
-                            <td>${user.id?html}</td>
+                            <td>${user.getID()?html}</td>
                             <td>${user.name?html}</td>
                         </tr>
                     </#list>


### PR DESCRIPTION
I'm not sure why {user.id} has stopped working, and we need to use the getter? Anyhow, this fixes it.