### PR TITLE
Update com.dropbox.core to 1.8.2

### DIFF
--- a/datavault-common/pom.xml
+++ b/datavault-common/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.dropbox.core</groupId>
             <artifactId>dropbox-core-sdk</artifactId>
-            <version>1.8.1</version>
+            <version>1.8.2</version>
         </dependency>
         
         <!-- Amazon Glacier -->


### PR DESCRIPTION
Resolves error found in testing deposit of images from Dropbox:

com.dropbox.core.DbxException$BadResponse: Bad JSON in
X-Dropbox-Metadata header: 1.125: "photo_info": expecting the end of an
object ("}")