### PR TITLE
Specify all Spring context files for loading in webapp

### DIFF
--- a/datavault-webapp/src/main/webapp/WEB-INF/spring-security.xml
+++ b/datavault-webapp/src/main/webapp/WEB-INF/spring-security.xml
@@ -71,8 +71,4 @@
         <property name="restService" ref="restService" />
     </bean>
 
-    <bean id="restService" class="org.datavaultplatform.webapp.services.RestService">
-        <property name="brokerURL" value="${brokerURL}" />
-    </bean>
-
 </beans>

--- a/datavault-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/datavault-webapp/src/main/webapp/WEB-INF/web.xml
@@ -51,7 +51,10 @@
 
     <context-param>
         <param-name>contextConfigLocation</param-name>
-        <param-value>/WEB-INF/spring-security.xml</param-value>
+        <param-value>
+            /WEB-INF/datavault-webapp-servlet.xml
+            /WEB-INF/spring-security.xml
+        </param-value>
     </context-param>
     
     <filter>


### PR DESCRIPTION
Specifying all the Spring context files in web.xml allows elements in one file to reference elements in another file. In this case it allows an AuthenticationProvider in security.xml to reference the RestService.