### PR TITLE
Disable buttons on submit

### DIFF
--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/create.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/create.ftl
@@ -75,8 +75,8 @@
         </script>
 
         <div class="form-group">
-            <button type="submit" name="action" value="submit" class="btn btn-primary"><span class="glyphicon glyphicon-save"></span> Deposit data</button>
-            <button type="submit" name="action" value="cancel" class="btn btn-danger cancel">Cancel</button>
+            <button type="submit" value="submit" class="btn btn-primary"><span class="glyphicon glyphicon-save"></span> Deposit data</button>
+            <button type="submit" value="cancel" class="btn btn-danger cancel">Cancel</button>
         </div>
 
         <input type="hidden" id="submitAction" name="action" value="submit"/>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/create.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/create.ftl
@@ -79,6 +79,7 @@
             <button type="submit" name="action" value="cancel" class="btn btn-danger cancel">Cancel</button>
         </div>
 
+        <input type="hidden" id="submitAction" name="action" value="submit"/>
         <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 
     </form>
@@ -86,6 +87,10 @@
 
 <script>
     $(document).ready(function () {
+
+        $('button[type="submit"]').on("click", function() {
+            $('#submitAction').val($(this).attr('value'));
+        });
 
         $('#create-deposit').validate({
             ignore: ".ignore",
@@ -103,6 +108,10 @@
             success: function (element) {
                 element.addClass('valid')
                     .closest('.form-group').removeClass('has-error').addClass('has-success');
+            },
+            submitHandler: function (form) {
+                $('button[type="submit"]').prop('disabled', true);
+                form.submit();
             }
         });
     });

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/restore.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/restore.ftl
@@ -69,8 +69,8 @@
         <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 
         <div class="form-group">
-            <button type="submit" name="action" value="submit" class="btn btn-primary"><span class="glyphicon glyphicon-open"></span> Restore data</button>
-            <button type="submit" name="action" value="cancel" class="btn btn-danger cancel">Cancel</button>
+            <button type="submit" value="submit" class="btn btn-primary"><span class="glyphicon glyphicon-open"></span> Restore data</button>
+            <button type="submit" value="cancel" class="btn btn-danger cancel">Cancel</button>
         </div>
 
     </form>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/restore.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/restore.ftl
@@ -65,6 +65,7 @@
             });
         </script>
 
+        <input type="hidden" id="submitAction" name="action" value="submit"/>
         <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 
         <div class="form-group">
@@ -78,6 +79,10 @@
 
 <script>
     $(document).ready(function () {
+
+        $('button[type="submit"]').on("click", function() {
+            $('#submitAction').val($(this).attr('value'));
+        });
 
         $('#restore-deposit').validate({
             ignore: ".ignore",
@@ -95,6 +100,10 @@
             success: function (element) {
                 element.addClass('valid')
                     .closest('.form-group').removeClass('has-error').addClass('has-success');
+            },
+            submitHandler: function (form) {
+                $('button[type="submit"]').prop('disabled', true);
+                form.submit();
             }
         });
 

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/create.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/create.ftl
@@ -61,8 +61,8 @@
         <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 
         <div class="form-group">
-            <button type="submit" name="action" value="submit" class="btn btn-primary"><span class="glyphicon glyphicon-folder-close"></span> Create new Vault</button>
-            <button type="submit" name="action" value="cancel" class="btn btn-danger cancel">Cancel</button>
+            <button type="submit" value="submit" class="btn btn-primary"><span class="glyphicon glyphicon-folder-close"></span> Create new Vault</button>
+            <button type="submit" value="cancel" class="btn btn-danger cancel">Cancel</button>
         </div>
 
     </form>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/create.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/create.ftl
@@ -57,6 +57,7 @@
             </select>
         </div>
 
+        <input type="hidden" id="submitAction" name="action" value="submit"/>
         <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 
         <div class="form-group">
@@ -71,6 +72,10 @@
 <script>
     $(document).ready(function () {
 
+        $('button[type="submit"]').on("click", function() {
+            $('#submitAction').val($(this).attr('value'));
+        });
+        
         $('#create-vault').validate({
             rules: {
                 name: {
@@ -86,6 +91,10 @@
             success: function (element) {
                 element.addClass('valid')
                     .closest('.form-group').removeClass('has-error').addClass('has-success');
+            },
+            submitHandler: function (form) {
+                $('button[type="submit"]').prop('disabled', true);
+                form.submit();
             }
         });
         


### PR DESCRIPTION
To prevent accidental submission of multiple requests the submit buttons are now disabled once clicked (if validation is successful).