### PR TITLE
Make Broker jsondoc relative path links work

### DIFF
--- a/datavault-broker/pom.xml
+++ b/datavault-broker/pom.xml
@@ -136,13 +136,13 @@
         <dependency>
             <groupId>org.jsondoc</groupId>
             <artifactId>jsondoc-springmvc</artifactId>
-            <version>1.2.9</version>
+            <version>1.2.11</version>
         </dependency>
 
         <dependency>
             <groupId>org.jsondoc</groupId>
             <artifactId>jsondoc-ui</artifactId>
-            <version>1.2.9</version>
+            <version>1.2.11</version>
         </dependency>
 
         <!-- Note: commons-logging is excluded and slf4j is the replacement bridge to log4j -->

--- a/datavault-broker/src/main/webapp/resources/index.html
+++ b/datavault-broker/src/main/webapp/resources/index.html
@@ -7,6 +7,10 @@
 <meta name="description" content="">
 <meta name="author" content="">
 
+<script type="text/javascript">
+	document.write("<base href='" + window.location.href + "/' />");
+</script>
+
 <script type="text/javascript" src="resources/js/jquery-1.11.1.min.js"></script>
 <script type="text/javascript" src="resources/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="resources/js/handlebars-1.0.0.beta.6.js"></script>
@@ -29,7 +33,7 @@
 		<div class="container-fluid">
     		<div class="navbar-header navbar-left">
 				<a class="navbar-brand" href="http://datavaultplatform.org">
-					<img alt="DataVault Logo" src="./resources/logo-dv.gif" height="40">
+					<img alt="DataVault Logo" src="resources/logo-dv.gif" height="40">
 				</a>
 			</div>
 		</div>


### PR DESCRIPTION
Didn't currently work as we were trying to invoke the jsondocs from a context of '/' rather than '/jsondoc'.