### PR TITLE
Add new verify stage to deposit process

### DIFF
--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/ArchiveStore.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/ArchiveStore.java
@@ -6,4 +6,6 @@ public interface ArchiveStore {
     
     // Properties and methods relating to archive organisation and operation
     
+    public Verify.Method verificationMethod = Verify.Method.COPY_BACK;
+    public Verify.Method getVerifyMethod();
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/Verify.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/Verify.java
@@ -1,7 +1,30 @@
 package org.datavaultplatform.common.storage;
 
+import java.io.*;
+import java.security.*;
+import javax.xml.bind.annotation.adapters.HexBinaryAdapter;
+
 public class Verify {
+    
+    private static final String algorithm = "SHA-1";
     
     public enum Method {LOCAL_ONLY, COPY_BACK};
     
+    public static String getSha1Digest(File file) throws Exception {
+
+        MessageDigest sha1 = MessageDigest.getInstance(algorithm);
+        
+        try (InputStream is = new FileInputStream(file)) {
+            byte[] buffer = new byte[8192];
+            int len = is.read(buffer);
+
+            while (len != -1) {
+                sha1.update(buffer, 0, len);
+                len = is.read(buffer);
+            }
+            
+            return new HexBinaryAdapter().marshal(sha1.digest());
+        }
+    }
+
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/Verify.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/Verify.java
@@ -1,0 +1,7 @@
+package org.datavaultplatform.common.storage;
+
+public class Verify {
+    
+    public enum Method {LOCAL_ONLY, COPY_BACK};
+    
+}

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/AmazonGlacier.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/AmazonGlacier.java
@@ -18,12 +18,18 @@ import com.amazonaws.services.glacier.transfer.UploadResult;
 import com.amazonaws.services.glacier.model.*;
 import com.amazonaws.services.sns.AmazonSNSClient;
 import com.amazonaws.services.sqs.AmazonSQSClient;
+import org.datavaultplatform.common.storage.Verify;
 
 // Documentation:
 // http://docs.aws.amazon.com/amazonglacier/latest/dev/using-aws-sdk-for-java.html
 // http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/glacier/AmazonGlacierClient.html
 
 public class AmazonGlacier extends Device implements ArchiveStore {
+    
+    // Amazon Glacier has retrieval costs so a full copy-back is undesirable.
+    // TODO: verify the hashes which are available from a glacier vault inventory.
+    // Vault inventory is carried out every 24 hours.
+    public Verify.Method verificationMethod = Verify.Method.LOCAL_ONLY;
     
     // A reference to the account which is related to the current credentials
     private String DEFAULT_ACCOUNT_NAME = "-";
@@ -168,5 +174,10 @@ public class AmazonGlacier extends Device implements ArchiveStore {
         
         // Glacier generates a new ID which is required retrieve data.
         return archiveId;
+    }
+    
+    @Override
+    public Verify.Method getVerifyMethod() {
+        return verificationMethod;
     }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/LocalFileSystem.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/LocalFileSystem.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.datavaultplatform.common.io.FileCopy;
+import org.datavaultplatform.common.storage.Verify;
 
 public class LocalFileSystem extends Device implements UserStore, ArchiveStore {
 
@@ -142,6 +143,12 @@ public class LocalFileSystem extends Device implements UserStore, ArchiveStore {
         }
         
         return working.getName();
+    }
+    
+    @Override
+    public Verify.Method getVerifyMethod() {
+        // Return the default verification method (copy back and check)
+        return verificationMethod;
     }
     
     private Path getAbsolutePath(String filePath) {


### PR DESCRIPTION
This verification is intended to check that:
* The archive package is not corrupted and can be extracted.
* The archive package (e.g. bagit) is internally consistent (e.g. all files listed in the manifest are present and have the correct contents).
* The archive package has been transferred successfully to the archive storage system.

Two verification strategies are implemented - COPY_BACK and LOCAL_ONLY. The particular archive storage plugin specifies which strategy should be used for a given archive storage device via getVerifyMethod().

The default COPY_BACK method restores data from archive storage, extracts and validates the bag. An SHA-1 hash is used to verify that the package which was copied back from the archive is identical to the package that was originally generated.

The alternative LOCAL_ONLY method is intended for services where a copy back is undesirable (e.g. Amazon Glacier where charges for data retrieval would apply and the data is not immediately available). In this case the temporary files are extracted and validated but the copy to the archive system is not fully checked at the point of deposit.

Additional checks of the file hash could be added later (but only where the archive storage system exposes this information e.g. a check on the hash from the Amazon Glacier inventory).