### PR TITLE
Add searchFilter to LDAP properties

### DIFF
--- a/datavault-assembly/src/datavault-home/config/datavault.properties
+++ b/datavault-assembly/src/datavault-home/config/datavault.properties
@@ -117,6 +117,7 @@ ldap.useSsl = true
 ldap.dn = uid=uun,ou=people,o=myu.ed
 ldap.password = secret
 ldap.searchContext = ou=people,o=myu.ed
+ldap.searchFilter = uid
 # A list of the attributes you want to retrieve from LDAP
 ldap.attrs = attr1,attr2,etc
 


### PR DESCRIPTION
Sorry, one I missed from the properties. Even if you are not using LDAP it still causes a runtime error as Spring looks for the property.