### PR TITLE
IssueId #RSS022-126 Added values to datavault.properties for the TSM …

### DIFF
--- a/datavault-assembly/src/datavault-home/config/datavault.properties
+++ b/datavault-assembly/src/datavault-home/config/datavault.properties
@@ -52,6 +52,12 @@ metaDir = /tmp/datavault/meta
 chunking.enabled = true
 chunking.size = 1GB
 
+# TSM and S3 options if required
+# ==============================
+# The directory containing NODE config files
+optionsDir = /opt/tivoli/tsm/client/ba/bin
+bucketName = datavault-test-bucket
+
 # Email server settings
 # =====================
 # The email account of the system administrator

--- a/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
@@ -75,6 +75,8 @@
         <property name="archiveStoreService" ref="archiveStoreService" />
         <property name="jobsService" ref="jobsService" />
         <property name="sender" ref="sender" />
+        <property name="optionsDir" value="${optionsDir:#{null}}" />
+        <property name="bucketName" value="${bucketName:#{null}}" />
     </bean>
 
     <bean id="statisticsController" class="org.datavaultplatform.broker.controllers.StatisticsController">

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/S3Cloud.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/S3Cloud.java
@@ -28,11 +28,15 @@ public class S3Cloud extends Device implements ArchiveStore {
 	private static final Logger logger = LoggerFactory.getLogger(S3Cloud.class);
 	public Verify.Method verificationMethod = Verify.Method.COPY_BACK;
 	private AmazonS3 s3;
-    private static final String bucketName = "datavault-test-bucket";
+    private static String bucketName = "datavault-test-bucket";
 	
 	public S3Cloud(String name, Map<String, String> config) {
 		super(name, config);
 		super.depositIdStorageKey = true;
+		if (config.containsKey("bucketName")) {
+        	String bucketName = config.get("bucketName");
+        	S3Cloud.bucketName = bucketName;
+        }
 		// the auth credentials are in ~/.aws/credentials
 		s3 = new AmazonS3Client();
 	    Region euWest1 = Region.getRegion(Regions.EU_WEST_1);

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.UUID;
 
 import org.datavaultplatform.common.io.Progress;
 import org.datavaultplatform.common.storage.ArchiveStore;
@@ -16,8 +15,11 @@ import org.slf4j.LoggerFactory;
 public class TivoliStorageManager extends Device implements ArchiveStore {
 
     private static final Logger logger = LoggerFactory.getLogger(TivoliStorageManager.class);
-    public static final String TSM_SERVER_NODE1_OPT = "/opt/tivoli/tsm/client/ba/bin/dsm1.opt";
-    public static final String TSM_SERVER_NODE2_OPT = "/opt/tivoli/tsm/client/ba/bin/dsm2.opt";
+    //public static final String TSM_SERVER_NODE1_OPT = "/opt/tivoli/tsm/client/ba/bin/dsm1.opt";
+    //public static final String TSM_SERVER_NODE2_OPT = "/opt/tivoli/tsm/client/ba/bin/dsm2.opt";
+    // default locations of TSM option files
+    public static String TSM_SERVER_NODE1_OPT = "/opt/tivoli/tsm/client/ba/bin/dsm1.opt";
+    public static String TSM_SERVER_NODE2_OPT = "/opt/tivoli/tsm/client/ba/bin/dsm2.opt";
     //public List<String> locations = null;
 
     // todo : can we change this to COPY_BACK?
@@ -25,6 +27,12 @@ public class TivoliStorageManager extends Device implements ArchiveStore {
 
     public TivoliStorageManager(String name, Map<String,String> config) throws Exception  {
         super(name, config);
+        // if we have non default options in datavault.properties use them
+        if (config.containsKey("optionsDir")) {
+        	String optionsDir = config.get("optionsDir");
+        	TivoliStorageManager.TSM_SERVER_NODE1_OPT = optionsDir + "/dsm1.opt";
+        	TivoliStorageManager.TSM_SERVER_NODE2_OPT = optionsDir + "/dsm2.opt";
+        }
         locations = new ArrayList<String>();
         locations.add(TivoliStorageManager.TSM_SERVER_NODE1_OPT);
         locations.add(TivoliStorageManager.TSM_SERVER_NODE2_OPT);
@@ -33,9 +41,6 @@ public class TivoliStorageManager extends Device implements ArchiveStore {
         for (String key : config.keySet()) {
         		logger.info("Config value for " + key + " is " + config.get(key));
         }
-
-        // Unpack the config parameters (in an implementation-specific way)
-        // Actually I can't think of any parameters that we need.
     }
     
     @Override


### PR DESCRIPTION
…and S3 plugins

1) Added optionsDir and bucketName params to the datavault.properties file if these params are missing and the plugins are selected for use default values from the plugins are used.
2) Added new addArchiveSpecificOptions method to the DepositsController and updated the deposit and retrieve method to use it.
3) Updated the datavault-broker-servlet.xml config file to inject the new values from the properties file to the deposits controller
4) Updated the S3Cloud and TivoliStorageManager plugins to use the new values if available

I've tested this manually with correct values in the properties, bad properties, missing properties etc. it all seems to work.

I might try and inject the values directly into the plugin if I get a chance but I'm not sure that is going to work the way things are set up.  If I get time I'll try.