### PR TITLE
IssueId #RSS022-180 Changed hibernate config so that the auto value i…

### DIFF
--- a/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-root.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-root.xml
@@ -188,8 +188,7 @@
                 <prop key="hibernate.dialect">org.hibernate.dialect.MySQLDialect</prop>
                 <prop key="hibernate.show_sql">false</prop>
                 <prop key="hibernate.format_sql">false</prop>
-                <!--<prop key="hibernate.hbm2ddl.auto">update</prop> -->
-                <prop key="hibernate.hbm2ddl.auto">create-drop</prop>
+                <prop key="hibernate.hbm2ddl.auto">none</prop>
                 <prop key="hibernate.enable_lazy_load_no_trans">true</prop>
                 <prop key="hibernate.hbm2ddl.import_files">/import.sql</prop>
             </props>

--- a/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-root.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-root.xml
@@ -188,7 +188,7 @@
                 <prop key="hibernate.dialect">org.hibernate.dialect.MySQLDialect</prop>
                 <prop key="hibernate.show_sql">false</prop>
                 <prop key="hibernate.format_sql">false</prop>
-                <prop key="hibernate.hbm2ddl.auto">none</prop>
+                <prop key="hibernate.hbm2ddl.auto">validate</prop>
                 <prop key="hibernate.enable_lazy_load_no_trans">true</prop>
                 <prop key="hibernate.hbm2ddl.import_files">/import.sql</prop>
             </props>


### PR DESCRIPTION
…s now none

1) Up until now we have been using create-drop and less successfully update as the hibernate.hbm2ddl.auto setting in datavault-broker-root.xml this means that every time we redeploy or restart Tomcat all previous data is lost.
Obviously we need to change that using the none value means any future db changes will need to be managed either manually or via something like Flyway.