### PR TITLE
IssueId #RSS022-181 Potential fix for the TSM retrieve issue

### DIFF
--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
@@ -22,6 +22,7 @@ public class TivoliStorageManager extends Device implements ArchiveStore {
     // default locations of TSM option files
     public static String TSM_SERVER_NODE1_OPT = "/opt/tivoli/tsm/client/ba/bin/dsm1.opt";
     public static String TSM_SERVER_NODE2_OPT = "/opt/tivoli/tsm/client/ba/bin/dsm2.opt";
+    public static String TEMP_PATH_PREFIX = "/tmp/datavault/temp/";
 
     public Verify.Method verificationMethod = Verify.Method.COPY_BACK;
 
@@ -77,8 +78,7 @@ public class TivoliStorageManager extends Device implements ArchiveStore {
     @Override
     public void retrieve(String depositId, File working, Progress progress, String optFilePath) throws Exception {
     	
-    	String tempDirPath = "/tmp/datavault/temp/";
-    	String fileDir = tempDirPath + "/" + depositId;
+    	String fileDir = TivoliStorageManager.TEMP_PATH_PREFIX + "/" + depositId;
     	String filePath = fileDir + "/" + working.getName();
     	Files.createDirectory(Paths.get(fileDir));
     	logger.info("Retrieve command is " + "dsmc " + " retrieve " + filePath + " -description=" + depositId + " -optfile=" + optFilePath + "-replace=true");
@@ -113,7 +113,7 @@ public class TivoliStorageManager extends Device implements ArchiveStore {
         // Note: generate a uuid to be passed as the description. We should probably use the deposit UUID instead (do we need a specialised archive method)?
         // Just a thought - Does the filename contain the deposit uuid? Could we use that as the description?
         //String randomUUIDString = UUID.randomUUID().toString();
-    	String pathPrefix = "/tmp/datavault/temp/";
+    	String pathPrefix = TivoliStorageManager.TEMP_PATH_PREFIX;
     	Path sourcePath = Paths.get(working.getAbsolutePath());
     	Path destinationDir = Paths.get(pathPrefix + depositId);
     	Path destinationFile = Paths.get(pathPrefix + depositId + "/" + working.getName());


### PR DESCRIPTION
This is a potential fix for the TSM issue where using a different worker from the one used to deposit causes the retrieve to fail.

I've updated the TSM plugin so that each file or chunk (depending on whether chunking is turned on) is now moved to a separate temp space while it is deposited / retrieved to / from each node.  This will slow things down but it does work on my machine, I can still retrieve after I've stopped and started the worker and Tomcat / worker too.

I'm not sure if this solution will work without further changes when we get around to threading the storage of the 3 copies, it might be better if we just add the original temp file location to the DB so that it can be extracted for the TSM plugin.

I'm committing this now so it doesn't get lost but I'm not going to merge until we've discussed at a sprint meeting.

We agreed at the sprint meeting to merge now so that we can push the fix to test.datavault but we may revisit this fix by storing the deposit path in the database rather than the moving to a TSM temp dir bodge contained here when we have time.