### PR TITLE
Add dataManagersService in vaultsController bean

### DIFF
--- a/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
@@ -59,6 +59,7 @@
         <property name="archiveStoreService" ref="archiveStoreService" />
         <property name="eventService" ref="eventService" />
         <property name="clientsService" ref="clientsService" />
+        <property name="dataManagersService" ref="dataManagersService" />
         <property name="activeDir" value="${activeDir}" />
         <property name="archiveDir" value="${archiveDir}" />
     </bean>


### PR DESCRIPTION
Just adding dataManagersService to VaultsController in datavault-broker-servlet.xml

It looks like that I forgot to add that when I've merged my work into master.