### PR TITLE
Remove typos and clarify text

### DIFF
--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/deposit.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/deposit.ftl
@@ -56,11 +56,11 @@
                         <td>${deposit.name?html}</td>
                     </tr>
                     <tr>
-                        <th scope="col">Desposited By</th>
+                        <th scope="col">Deposited By</th>
                         <td>${deposit.getUserID()}</td>
                     </tr>
                     <tr>
-                        <th scope="col">Desposit Size</th>
+                        <th scope="col">Deposit Size</th>
                         <td>${deposit.getSizeStr()}</td>
                     </tr>
                     <tr>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/vault.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/vault.ftl
@@ -62,7 +62,7 @@
                         <th>Deposited By</th>
                         <th>Date and Time</th>
                         <th>Total Size of Selected Deposits</th>
-                        <th>Select Desposit(s) to be Retrieved
+                        <th>Select Deposit(s) to be Retrieved
                             <span class="glyphicon glyphicon-info-sign text-muted" aria-hidden="true" data-toggle="tooltip" 
                                 title="Please make sure you have enough space for the full contents of the vault to be copied to the location you will specify (see 'Size', below).">
                             </span>
@@ -165,9 +165,10 @@
                     </table>
                     <div class="alert alert-info" role="alert">
                         <p>
-                            All vaults are automatically closed so no more deposits can be added
-                            ONE calendar year after the grant end date or one year after the first
-                            deposit, whichever is later.
+                            You will not be able to add new deposits to this Vault once it is closed.
+                            The Vault will be closed ONE calendar year after the first deposit.
+                            Or, if you specify a Grant End Date,
+                            ONE calendar year after the Grant End Date IF that falls later than one year after the first deposit.
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
Update the vault page text
Remove 'Desposit' typo instead of 'Deposit' in several places