### PR TITLE
Fix Build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,25 +12,30 @@ services:
   - docker
   
 before_install:
-  # - setup_docker.sh
-  - mvn install:install-file -Dfile=datavault-common/src/main/resources/ftm-api-2.4.2.jar -DgroupId=oracle.cloudstorage.ftm -DartifactId=ftm-api -Dversion=1.0 -Dpackaging=jar
-  - mvn install:install-file -Dfile=datavault-common/src/main/resources/low-level-api-core-1.14.19.jar -DgroupId=oracle.cloudstorage.ftm -DartifactId=low-level-api-core -Dversion=1.0 -Dpackaging=jar
   - docker-compose rm -f
-  - docker-compose pull
 
-script: 
-  # docker needs jar file to start
+script: build
+  # Run maven unit test
   - mvn clean test package
-  - service docker status
-  - docker-compose build
+  # First run the maven build container (also run the unit test)
+  - docker-compose build maven-build
+  # Start required services
   - docker-compose up -d rabbitmq mysql vault vault-administration
   - sleep 60 # wait that containers are ready
+  # Make sure rabbitmq is running properly
   - docker-compose logs rabbitmq
   - docker-compose exec rabbitmq rabbitmqctl authenticate_user datavault datavault
+  # Build the workers container and run
+  - docker-compose build workers
   - docker-compose up -d workers
+  # Delete unused containers
+  - docker-compose rm -f maven-build
+  - docker-compose rm -f vault-administration
+  # Check everything is running as expected
   - sleep 60 # wait that container is ready
   - docker-compose logs workers
   - docker-compose ps
+  # Run integration tests
   - mvn verify -P integration-test
   - sed -i 's/chunking\.enabled = true/chunking.enabled = false/' docker/config/datavault.properties
   - docker-compose restart workers

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 before_install:
   - docker-compose rm -f
 
-script: build
+script:
   # Run maven unit test
   - mvn clean test package
   # First run the maven build container (also run the unit test)

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,26 +18,23 @@ script:
   # Run maven unit test
   - mvn clean test package
   # First run the maven build container (also run the unit test)
-  - docker-compose build maven-build
+  - docker-compose up -d --build maven-build
   # Start required services
   - docker-compose up -d rabbitmq mysql vault vault-administration
   # Check everything is running as expected
   - sleep 60 # wait that container is ready
-  - docker-compose logs workers
-  - docker ps -a
   # Make sure rabbitmq is running properly
   - docker-compose logs rabbitmq
   - docker-compose exec rabbitmq rabbitmqctl authenticate_user datavault datavault
   # Build the workers container and run
-  - docker-compose build workers
-  - docker-compose up -d workers
+  - sudo docker-compose up -d --build workers
   # Delete unused containers
   - docker-compose rm -f maven-build
   - docker-compose rm -f vault-administration
   # Check everything is running as expected
   - sleep 60 # wait that container is ready
   - docker-compose logs workers
-  - docker ps -a
+  - docker-compose ps
   # Run integration tests
   - mvn verify -P integration-test
   - sed -i 's/chunking\.enabled = true/chunking.enabled = false/' docker/config/datavault.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,10 @@ script:
   - docker-compose build maven-build
   # Start required services
   - docker-compose up -d rabbitmq mysql vault vault-administration
-  - sleep 60 # wait that containers are ready
+  # Check everything is running as expected
+  - sleep 60 # wait that container is ready
+  - docker-compose logs workers
+  - docker ps -a
   # Make sure rabbitmq is running properly
   - docker-compose logs rabbitmq
   - docker-compose exec rabbitmq rabbitmqctl authenticate_user datavault datavault
@@ -34,7 +37,7 @@ script:
   # Check everything is running as expected
   - sleep 60 # wait that container is ready
   - docker-compose logs workers
-  - docker-compose ps
+  - docker ps -a
   # Run integration tests
   - mvn verify -P integration-test
   - sed -i 's/chunking\.enabled = true/chunking.enabled = false/' docker/config/datavault.properties

--- a/broker.Dockerfile
+++ b/broker.Dockerfile
@@ -1,34 +1,3 @@
-FROM maven:3-jdk-8
-
-ENV MAVEN_OPTS "-Xmx1024m"
-
-# By default this is empty, but if you've built the package locally (without Docker) you can speed up repeated builds by copying your ~/.m2/repository into docker/m2/repository
-# Any dependencies you don't have will still be downloaded as normal
-COPY docker/m2/repository /root/.m2/repository
-
-# Copy just the pom files to cache the dependencies
-COPY datavault-assembly/pom.xml /tmp/datavault-assembly/pom.xml
-COPY datavault-broker/pom.xml /tmp/datavault-broker/pom.xml
-COPY datavault-common/pom.xml /tmp/datavault-common/pom.xml
-COPY datavault-webapp/pom.xml /tmp/datavault-webapp/pom.xml
-COPY datavault-worker/pom.xml /tmp/datavault-worker/pom.xml
-COPY pom.xml /tmp
-COPY datavault-common/src/main/resources/ftm-api-2.4.2.jar /tmp
-COPY datavault-common/src/main/resources/low-level-api-core-1.14.19.jar /tmp
-WORKDIR /tmp
-RUN mvn install:install-file -Dfile=/tmp/ftm-api-2.4.2.jar -DgroupId=oracle.cloudstorage.ftm -DartifactId=ftm-api -Dversion=1.0 -Dpackaging=jar
-RUN mvn install:install-file -Dfile=/tmp/low-level-api-core-1.14.19.jar -DgroupId=oracle.cloudstorage.ftm -DartifactId=low-level-api-core -Dversion=1.0 -Dpackaging=jar
-RUN mvn dependency:go-offline --fail-never
-# The dependency:go-offline gets a lot of the dependencies, but not all. This would get more, but not sure about other implications
-#RUN mvn -s /usr/share/maven/ref/settings-docker.xml install --fail-never
-
-COPY . /usr/src
-WORKDIR /usr/src
-RUN mvn clean test package
-
-RUN curl -sLo /usr/local/bin/ep https://github.com/kreuzwerker/envplate/releases/download/v0.0.8/ep-linux && chmod +x /usr/local/bin/ep
-RUN curl -sLo /usr/local/bin/wait-for-it https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && chmod +x /usr/local/bin/wait-for-it
-
 FROM tomcat:7-jre8-alpine
 
 MAINTAINER William Petit <w.petit@ed.ac.uk>
@@ -39,10 +8,11 @@ ENV DATAVAULT_HOME "/docker_datavault-home"
 
 RUN apk add --no-cache mysql curl su-exec
 
-COPY --from=0 /usr/local/bin/ep /usr/local/bin/ep
-COPY --from=0 /usr/local/bin/wait-for-it /usr/local/bin/wait-for-it
-COPY --from=0 /usr/src/datavault-assembly/target/datavault-assembly-1.0-SNAPSHOT-assembly/datavault-home/lib ${DATAVAULT_HOME}/lib
-COPY --from=0 /usr/src/datavault-assembly/target/datavault-assembly-1.0-SNAPSHOT-assembly/datavault-home/webapps ${DATAVAULT_HOME}/webapps
+COPY --from=datavault/maven-build /usr/local/bin/ep /usr/local/bin/ep
+COPY --from=datavault/maven-build /usr/local/bin/wait-for-it /usr/local/bin/wait-for-it
+COPY --from=datavault/maven-build /usr/src/datavault-assembly/target/datavault-assembly-1.0-SNAPSHOT-assembly/datavault-home/lib ${DATAVAULT_HOME}/lib
+COPY --from=datavault/maven-build /usr/src/datavault-assembly/target/datavault-assembly-1.0-SNAPSHOT-assembly/datavault-home/webapps ${DATAVAULT_HOME}/webapps
+
 COPY docker/config ${DATAVAULT_HOME}/config
 COPY docker/scripts ${DATAVAULT_HOME}/scripts
 COPY docker/pure/ /tmp/

--- a/datavault-broker/pom.xml
+++ b/datavault-broker/pom.xml
@@ -274,6 +274,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.1.0.RELEASE</version>
             </plugin>
         </plugins>
     </build>

--- a/datavault-common/pom.xml
+++ b/datavault-common/pom.xml
@@ -95,12 +95,16 @@
         <dependency>
     		<groupId>oracle.cloudstorage.ftm</groupId>
     		<artifactId>ftm-api</artifactId>
-    		<version>1.0</version>
-  		</dependency>    
+    		<version>2.4.2</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/src/main/resources/ftm-api-2.4.2.jar</systemPath>
+  		</dependency>
         <dependency>
-                <groupId>oracle.cloudstorage.ftm</groupId>
-                <artifactId>low-level-api-core</artifactId>
-                <version>1.0</version>
+            <groupId>oracle.cloudstorage.ftm</groupId>
+            <artifactId>low-level-api-core</artifactId>
+            <version>1.14.19</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/src/main/resources/low-level-api-core-1.14.19.jar</systemPath>
         </dependency>
         <dependency>
     		<groupId>org.glassfish</groupId>

--- a/datavault-webapp/pom.xml
+++ b/datavault-webapp/pom.xml
@@ -136,11 +136,6 @@
         
         <!--  Selenium -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-        </dependency>
-        <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
             </dependency>

--- a/datavault-worker/pom.xml
+++ b/datavault-worker/pom.xml
@@ -190,7 +190,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20.1</version>
+                <version>2.22.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '3'
 services:
   rabbitmq:
     image: rabbitmq:3-management-alpine
@@ -31,8 +31,12 @@ services:
       MYSQL_PASSWORD: datavault
     networks:
       - dbnet
-    volumes:
-      - ./docker/mysql:/var/lib/mysql
+
+  maven-build:
+    image: datavault/maven-build
+    build:
+      context: .
+      dockerfile: maven.Dockerfile
 
   workers:
     build:
@@ -53,6 +57,7 @@ services:
       - vault
     depends_on:
       - rabbitmq
+      - maven-build
 
   broker:
     build:

--- a/maven.Dockerfile
+++ b/maven.Dockerfile
@@ -1,0 +1,40 @@
+FROM maven:3.5.2-jdk-8
+
+ENV MAVEN_OPTS "-Xmx1024m"
+
+RUN curl -sLo /usr/local/bin/ep https://github.com/kreuzwerker/envplate/releases/download/v0.0.8/ep-linux && chmod +x /usr/local/bin/ep
+RUN curl -sLo /usr/local/bin/wait-for-it https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && chmod +x /usr/local/bin/wait-for-it
+
+# Copy just the pom files to cache the dependencies
+#COPY datavault-assembly/pom.xml /tmp/datavault-assembly/pom.xml
+#COPY datavault-broker/pom.xml /tmp/datavault-broker/pom.xml
+#COPY datavault-common/pom.xml /tmp/datavault-common/pom.xml
+#COPY datavault-webapp/pom.xml /tmp/datavault-webapp/pom.xml
+#COPY datavault-worker/pom.xml /tmp/datavault-worker/pom.xml
+#COPY pom.xml /tmp
+#COPY datavault-common/src/main/resources/ftm-api-2.4.2.jar /tmp
+#COPY datavault-common/src/main/resources/low-level-api-core-1.14.19.jar /tmp
+#WORKDIR /tmp
+# RUN mvn install:install-file -Dfile=/tmp/ftm-api-2.4.2.jar -DgroupId=oracle.cloudstorage.ftm -DartifactId=ftm-api -Dversion=2.4.2 -Dpackaging=jar
+# RUN mvn install:install-file -Dfile=/tmp/low-level-api-core-1.14.19.jar -DgroupId=oracle.cloudstorage.ftm -DartifactId=low-level-api-core -Dversion=1.14.19 -Dpackaging=jar
+
+#RUN mvn dependency:go-offline --fail-never
+# The dependency:go-offline gets a lot of the dependencies, but not all. This would get more, but not sure about other implications
+#RUN mvn -s /usr/share/maven/ref/settings-docker.xml install --fail-never
+
+#RUN mvn clean package --projects datavault-common
+#RUN mvn clean package --projects datavault-broker
+#RUN mvn clean package --projects datavault-webapp
+#RUN mvn clean package --projects datavault-worker
+#RUN mvn clean package --projects datavault-assembly
+
+WORKDIR /usr/src
+
+# By default this is empty, but if you've built the package locally (without Docker) you can speed up repeated builds by copying your ~/.m2/repository into docker/m2/repository
+# Any dependencies you don't have will still be downloaded as normal
+COPY docker/m2/repository /root/.m2/repository
+
+COPY . /usr/src
+
+RUN mvn clean
+RUN mvn -Dmaven.test.skip=true package

--- a/webapp.Dockerfile
+++ b/webapp.Dockerfile
@@ -1,34 +1,3 @@
-FROM maven:3-jdk-8
-
-ENV MAVEN_OPTS "-Xmx1024m"
-
-# By default this is empty, but if you've built the package locally (without Docker) you can speed up repeated builds by copying your ~/.m2/repository into docker/m2/repository
-# Any dependencies you don't have will still be downloaded as normal
-COPY docker/m2/repository /root/.m2/repository
-
-# Copy just the pom files to cache the dependencies
-COPY datavault-assembly/pom.xml /tmp/datavault-assembly/pom.xml
-COPY datavault-broker/pom.xml /tmp/datavault-broker/pom.xml
-COPY datavault-common/pom.xml /tmp/datavault-common/pom.xml
-COPY datavault-webapp/pom.xml /tmp/datavault-webapp/pom.xml
-COPY datavault-worker/pom.xml /tmp/datavault-worker/pom.xml
-COPY pom.xml /tmp
-COPY datavault-common/src/main/resources/ftm-api-2.4.2.jar /tmp
-COPY datavault-common/src/main/resources/low-level-api-core-1.14.19.jar /tmp
-WORKDIR /tmp
-RUN mvn install:install-file -Dfile=/tmp/ftm-api-2.4.2.jar -DgroupId=oracle.cloudstorage.ftm -DartifactId=ftm-api -Dversion=1.0 -Dpackaging=jar
-RUN mvn install:install-file -Dfile=/tmp/low-level-api-core-1.14.19.jar -DgroupId=oracle.cloudstorage.ftm -DartifactId=low-level-api-core -Dversion=1.0 -Dpackaging=jar
-RUN mvn dependency:go-offline --fail-never
-# The dependency:go-offline gets a lot of the dependencies, but not all. This would get more, but not sure about other implications
-#RUN mvn -s /usr/share/maven/ref/settings-docker.xml install --fail-never
-
-COPY . /usr/src
-WORKDIR /usr/src
-RUN mvn clean test package
-
-RUN curl -sLo /usr/local/bin/ep https://github.com/kreuzwerker/envplate/releases/download/v0.0.8/ep-linux && chmod +x /usr/local/bin/ep
-RUN curl -sLo /usr/local/bin/wait-for-it https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && chmod +x /usr/local/bin/wait-for-it
-
 FROM tomcat:7-jre8-alpine
 
 MAINTAINER William Petit <w.petit@ed.ac.uk>
@@ -39,11 +8,12 @@ ENV DATAVAULT_HOME "/docker_datavault-home"
 
 RUN apk add --no-cache su-exec openssh
 
-COPY --from=0 /usr/local/bin/ep /usr/local/bin/ep
-COPY --from=0 /usr/local/bin/wait-for-it /usr/local/bin/wait-for-it
-COPY --from=0 /usr/src/datavault-assembly/target/datavault-assembly-1.0-SNAPSHOT-assembly/datavault-home/lib ${DATAVAULT_HOME}/lib
-COPY --from=0 /usr/src/datavault-assembly/target/datavault-assembly-1.0-SNAPSHOT-assembly/datavault-home/webapps ${DATAVAULT_HOME}/webapps
-COPY --from=0 /usr/src/datavault-assembly/target/datavault-assembly-1.0-SNAPSHOT-assembly/datavault-home/bin ${DATAVAULT_HOME}/bin
+COPY --from=datavault/maven-build /usr/local/bin/ep /usr/local/bin/ep
+COPY --from=datavault/maven-build /usr/local/bin/wait-for-it /usr/local/bin/wait-for-it
+COPY --from=datavault/maven-build /usr/src/datavault-assembly/target/datavault-assembly-1.0-SNAPSHOT-assembly/datavault-home/lib ${DATAVAULT_HOME}/lib
+COPY --from=datavault/maven-build /usr/src/datavault-assembly/target/datavault-assembly-1.0-SNAPSHOT-assembly/datavault-home/webapps ${DATAVAULT_HOME}/webapps
+COPY --from=datavault/maven-build /usr/src/datavault-assembly/target/datavault-assembly-1.0-SNAPSHOT-assembly/datavault-home/bin ${DATAVAULT_HOME}/bin
+
 COPY docker/config ${DATAVAULT_HOME}/config
 COPY docker/scripts ${DATAVAULT_HOME}/scripts
 

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -1,34 +1,3 @@
-FROM maven:3-jdk-8
-
-ENV MAVEN_OPTS "-Xmx1024m"
-
-# By default this is empty, but if you've built the package locally (without Docker) you can speed up repeated builds by copying your ~/.m2/repository into docker/m2/repository
-# Any dependencies you don't have will still be downloaded as normal
-COPY docker/m2/repository /root/.m2/repository
-
-# Copy just the pom files to cache the dependencies
-COPY datavault-assembly/pom.xml /tmp/datavault-assembly/pom.xml
-COPY datavault-broker/pom.xml /tmp/datavault-broker/pom.xml
-COPY datavault-common/pom.xml /tmp/datavault-common/pom.xml
-COPY datavault-webapp/pom.xml /tmp/datavault-webapp/pom.xml
-COPY datavault-worker/pom.xml /tmp/datavault-worker/pom.xml
-COPY pom.xml /tmp
-COPY datavault-common/src/main/resources/ftm-api-2.4.2.jar /tmp
-COPY datavault-common/src/main/resources/low-level-api-core-1.14.19.jar /tmp
-WORKDIR /tmp
-RUN mvn install:install-file -Dfile=/tmp/ftm-api-2.4.2.jar -DgroupId=oracle.cloudstorage.ftm -DartifactId=ftm-api -Dversion=1.0 -Dpackaging=jar
-RUN mvn install:install-file -Dfile=/tmp/low-level-api-core-1.14.19.jar -DgroupId=oracle.cloudstorage.ftm -DartifactId=low-level-api-core -Dversion=1.0 -Dpackaging=jar
-RUN mvn dependency:go-offline --fail-never
-# The dependency:go-offline gets a lot of the dependencies, but not all. This would get more, but not sure about other implications
-#RUN mvn -s /usr/share/maven/ref/settings-docker.xml install --fail-never
-
-COPY . /usr/src
-WORKDIR /usr/src
-RUN mvn clean test package
-
-RUN curl -sLo /usr/local/bin/ep https://github.com/kreuzwerker/envplate/releases/download/v0.0.8/ep-linux && chmod +x /usr/local/bin/ep
-RUN curl -sLo /usr/local/bin/wait-for-it https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && chmod +x /usr/local/bin/wait-for-it
-
 FROM openjdk:8-jre-alpine
 
 MAINTAINER William Petit <w.petit@ed.ac.uk>
@@ -38,9 +7,11 @@ ENV DATAVAULT_HOME "/docker_datavault-home"
 RUN apk add --no-cache bash curl su-exec
 
 RUN mkdir -p ${DATAVAULT_HOME}/lib
-COPY --from=0 /usr/local/bin/ep /usr/local/bin/ep
-COPY --from=0 /usr/local/bin/wait-for-it /usr/local/bin/wait-for-it
-COPY --from=0 /usr/src/datavault-worker/target/datavault-worker-1.0-SNAPSHOT-jar-with-dependencies-spring.jar ${DATAVAULT_HOME}/lib/datavault-worker-1.0-SNAPSHOT-jar-with-dependencies-spring.jar
+
+COPY --from=datavault/maven-build /usr/local/bin/ep /usr/local/bin/ep
+COPY --from=datavault/maven-build /usr/local/bin/wait-for-it /usr/local/bin/wait-for-it
+COPY --from=datavault/maven-build /usr/src/datavault-worker/target/datavault-worker-1.0-SNAPSHOT-jar-with-dependencies-spring.jar ${DATAVAULT_HOME}/lib/datavault-worker-1.0-SNAPSHOT-jar-with-dependencies-spring.jar
+
 COPY docker/config ${DATAVAULT_HOME}/config
 COPY docker/scripts ${DATAVAULT_HOME}/scripts
 


### PR DESCRIPTION
- Moved maven build into a separate container called `maven-build`
- the web, broker and worker container all get what they need from the `maven-build` container
- Comment out: `mvn dependency:go-offline --fail-never` as it seems to cause the issue
- Instead of using `mvn install` for the oracle packages, use `systemPath` in the pom file.
- Update the .travis file.