### PR TITLE
RSS022-305 - Make sure Deposit and Retrieve stop if any Exception occure

### DIFF
--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Deposit.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Deposit.java
@@ -134,7 +134,8 @@ public class Deposit extends Task {
                 e.printStackTrace();
                 eventStream.send(new Error(jobID, depositId, msg)
                     .withUserId(userID));
-                return;
+
+                System.exit(1);
             }
         }
         
@@ -159,7 +160,8 @@ public class Deposit extends Task {
                 logger.error(msg, e);
                 eventStream.send(new Error(jobID, depositId, msg)
                         .withUserId(userID));
-                return;
+
+                System.exit(1);
             }
         }
         
@@ -178,7 +180,8 @@ public class Deposit extends Task {
                 logger.error(msg, e);
                 eventStream.send(new Error(jobID, depositId, msg)
                     .withUserId(userID));
-                return;
+
+                System.exit(1);
             }
         }
         
@@ -252,7 +255,8 @@ public class Deposit extends Task {
                 logger.error(msg, e);
                 eventStream.send(new Error(jobID, depositId, msg)
                     .withUserId(userID));
-                return;
+
+                System.exit(1);
             }
         }
         
@@ -424,6 +428,8 @@ public class Deposit extends Task {
             logger.error(msg, e);
             eventStream.send(new Error(jobID, depositId, msg)
                 .withUserId(userID));
+
+            System.exit(1);
         }
         
         // TODO: Disconnect from user and archive storage system?

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Deposit.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Deposit.java
@@ -252,6 +252,7 @@ public class Deposit extends Task {
                 logger.error(msg, e);
                 eventStream.send(new Error(jobID, depositId, msg)
                     .withUserId(userID));
+                return;
             }
         }
         

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Retrieve.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Retrieve.java
@@ -156,6 +156,7 @@ public class Retrieve extends Task {
                 logger.info("Unable to determine free space");
                 eventStream.send(new Error(jobID, depositId, "Unable to determine free space")
                     .withUserId(userID));
+                return;
             }
 
             // Retrieve the archived data
@@ -211,6 +212,7 @@ public class Retrieve extends Task {
                             logger.info("All locations had problems throwing exception " + e.getMessage());
                             throw e;
                         }
+                        return;
                     }
                 }
 

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Retrieve.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Retrieve.java
@@ -116,7 +116,8 @@ public class Retrieve extends Task {
                 logger.error(msg, e);
                 eventStream.send(new Error(jobID, depositId, msg)
                     .withUserId(userID));
-                return;
+
+                System.exit(1);
             }
         }
 
@@ -134,7 +135,8 @@ public class Retrieve extends Task {
             logger.error(msg, e);
             eventStream.send(new Error(jobID, depositId, msg)
                 .withUserId(userID));
-            return;
+
+            System.exit(1);
         }
         
         try {
@@ -156,7 +158,8 @@ public class Retrieve extends Task {
                 logger.info("Unable to determine free space");
                 eventStream.send(new Error(jobID, depositId, "Unable to determine free space")
                     .withUserId(userID));
-                return;
+
+                System.exit(1);
             }
 
             // Retrieve the archived data
@@ -212,7 +215,7 @@ public class Retrieve extends Task {
                             logger.info("All locations had problems throwing exception " + e.getMessage());
                             throw e;
                         }
-                        return;
+                        System.exit(1);
                     }
                 }
 
@@ -268,6 +271,8 @@ public class Retrieve extends Task {
             logger.error(msg, e);
             eventStream.send(new Error(jobID, depositId, msg)
                 .withUserId(userID));
+
+            System.exit(1);
         }
     }
     


### PR DESCRIPTION
We had previous issue where the Deposit would continue taring,
encrypting, archiving even though the File transfer failed in the middle
of the process. We believe this is because the catch close doesn't
contain a `return`.o I looks at every catch close which could have the
same issue in Deposit.java and Retrieve.java and added the `return`.