### PR TITLE
Rss022 310

### DIFF
--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RetentionPolicyDAOImpl.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RetentionPolicyDAOImpl.java
@@ -41,7 +41,7 @@ public class RetentionPolicyDAOImpl implements RetentionPolicyDAO {
     public List<RetentionPolicy> list() {
         Session session = this.sessionFactory.openSession();
         Criteria criteria = session.createCriteria(RetentionPolicy.class);
-        criteria.addOrder(Order.asc("sort"));
+        criteria.addOrder(Order.asc("name"));
         List<RetentionPolicy> policies = criteria.list();
         session.close();
         return policies;

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystem.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystem.java
@@ -12,10 +12,12 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.InputStream;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import java.util.Date;
 
 public class SFTPFileSystem extends Device implements UserStore {
 
@@ -315,7 +317,7 @@ public class SFTPFileSystem extends Device implements UserStore {
     
     @Override
     public String store(String path, File working, Progress progress) throws Exception {
-        
+
         // Strip any leading separators (we want a path relative to the current dir)
         while (path.startsWith(PATH_SEPARATOR)) {
             path = path.replaceFirst(PATH_SEPARATOR, "");
@@ -323,9 +325,17 @@ public class SFTPFileSystem extends Device implements UserStore {
         
         try {
             Connect();
-            
+
             path = channelSftp.pwd() + "/" + path;
             channelSftp.cd(path);
+
+            // Create timestamped folder to avoid overwriting files
+            String timeStamp = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
+            String timestampDirName = "dv_" + timeStamp;
+            path = path + PATH_SEPARATOR + timestampDirName;
+
+            channelSftp.mkdir(timestampDirName);
+            channelSftp.cd(timestampDirName);
             
             if (working.isDirectory()) {
                 // Create top-level directory


### PR DESCRIPTION
I've first created a timestamped folder to avoid overwriting files as we though the error we were experiencing were due to that. But the issue was still happening. 
What I found out is that if instead of using the full path when creating a folder, we cd in the parent folder and create the folder with just its name it works.

I've push by mistake some change for the retention policy in this PR, but I guess that's fine.