### PR TITLE
Fix the existing TSM code so that if the first copy is missing or a chunk has checksum issues it restarts the retrieval using the second node

### DIFF
--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
@@ -88,7 +88,7 @@ public class TivoliStorageManager extends Device implements ArchiveStore {
     	
     	String fileDir = TivoliStorageManager.TEMP_PATH_PREFIX + "/" + depositId;
     	String filePath = fileDir + "/" + working.getName();
-    	if (Files.exists(Paths.get(fileDir))) {
+    	if (! Files.exists(Paths.get(fileDir))) {
     		Files.createDirectory(Paths.get(fileDir));
     	}
     	logger.info("Retrieve command is " + "dsmc " + " retrieve " + filePath + " -description=" + depositId + " -optfile=" + optFilePath + "-replace=true");

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
@@ -88,7 +88,9 @@ public class TivoliStorageManager extends Device implements ArchiveStore {
     	
     	String fileDir = TivoliStorageManager.TEMP_PATH_PREFIX + "/" + depositId;
     	String filePath = fileDir + "/" + working.getName();
-    	Files.createDirectory(Paths.get(fileDir));
+    	if (Files.exists(Paths.get(fileDir))) {
+    		Files.createDirectory(Paths.get(fileDir));
+    	}
     	logger.info("Retrieve command is " + "dsmc " + " retrieve " + filePath + " -description=" + depositId + " -optfile=" + optFilePath + "-replace=true");
     		
         ProcessBuilder pb = new ProcessBuilder("dsmc", "retrieve", filePath, "-description=" + depositId, "-optfile=" + optFilePath, "-replace=true");

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Retrieve.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Retrieve.java
@@ -221,9 +221,6 @@ public class Retrieve extends Task {
                         	logger.info("Current " + location + " has a problem trying next location");
                         	continue LOCATION;
                         }
-                        //System.exit(1);
-                        //throw new RuntimeException(e);
-
                     }
                 }
 

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Retrieve.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Retrieve.java
@@ -187,6 +187,7 @@ public class Retrieve extends Task {
                 Iterator<String> locationsIt = locations.iterator();
                 LOCATION: while (locationsIt.hasNext()) {
                     String location = locationsIt.next();
+                    logger.info("Current " + location);
                     try {
                         try {
                             // NEED TO UPDATE THIS TO INCLUDE CHUNKING STUFF IS TURNED ON
@@ -217,6 +218,7 @@ public class Retrieve extends Task {
                             logger.info("All locations had problems throwing exception " + e.getMessage());
                             throw e;
                         } else {
+                        	logger.info("Current " + location + " has a problem trying next location");
                         	continue LOCATION;
                         }
                         //System.exit(1);

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Retrieve.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Retrieve.java
@@ -213,13 +213,15 @@ public class Retrieve extends Task {
                     } catch (Exception e) {
                         // if last location has an error throw the error else go
                         // round again
-                        // continue LOCATION;
                         if (!locationsIt.hasNext()) {
                             logger.info("All locations had problems throwing exception " + e.getMessage());
                             throw e;
+                        } else {
+                        	continue LOCATION;
                         }
                         //System.exit(1);
-                        throw new RuntimeException(e);
+                        //throw new RuntimeException(e);
+
                     }
                 }
 


### PR DESCRIPTION
Fix the existing TSM code so that if the first copy is missing or a chunk has checksum issues it restarts the retrieval using the second node.

(The whole TSM plugin could probably do with a rewrite especially the fact it restarts the retrieval instead of just getting any problem chunks from the 2nd node while continuing but that is for another time)