### PR TITLE
RSS044-24 - Quick fix for the create deposit page

### DIFF
--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/create.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/create.ftl
@@ -305,7 +305,7 @@
 </div>
 
 <script>
-    $(document).ready(function () {
+    $(function () {
 
         $('[data-toggle="popover"]').popover();
         
@@ -325,13 +325,7 @@
         });
         
         $('#add-from-storage-btn').on("click", function() {
-
-            // Add the path to the hidden control
             var node = $("#tree").fancytree("getActiveNode");
-            $('.file-path')
-                .append($('<option>', { value : node.key })
-                    .text(node.key)
-                    .prop('selected', true));
 
             var storageNode = $("#upload-tree").fancytree("getNodeByKey", "storage");
 
@@ -362,7 +356,13 @@
                     }
 
                     if(!isFull) {
-                        // Add the file to the list
+                        // Add the path to the hidden control
+                        $('.file-path')
+                            .append($('<option>', { value : node.key })
+                                .text(node.key)
+                                .prop('selected', true));
+
+                        //Show tree
                         $("#upload-tree").show();
 
                         if (!storageNode) {


### PR DESCRIPTION
There is an hidden select box which get updated when pressing the "Add" button and the function was still adding the path into it. Now it should only add it if the deposit is not already full.