### PR TITLE
Updated the version of jackson-databind in top level pom.xml

### DIFF
--- a/datavault-broker/pom.xml
+++ b/datavault-broker/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.8</version>
+            <version>1.18</version>
         </dependency>
 
         <dependency>
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>com.rabbitmq</groupId>
             <artifactId>amqp-client</artifactId>
-            <version>3.5.2</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/datavault-webapp/pom.xml
+++ b/datavault-webapp/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.3</version>
+            <version>1.3.3</version>
         </dependency>
         
         <!--  Selenium -->

--- a/datavault-worker/pom.xml
+++ b/datavault-worker/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.8</version>
+            <version>1.18</version>
         </dependency>
 
         <dependency>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.rabbitmq</groupId>
             <artifactId>amqp-client</artifactId>
-            <version>3.5.2</version>
+            <version>4.8.0</version>
         </dependency>
 
         <!-- Jackson JSON Processor -->
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>1.10</version>
+            <version>[1.20,)</version>
         </dependency>
 
         <!-- Note: commons-logging is excluded and slf4j is the replacement bridge to log4j -->

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.5.3</version>
+                <version>2.7.9.4</version>
             </dependency>
 
             <!-- MySQL -->


### PR DESCRIPTION
I've updated the mvn dependency we got a warning from GitHub for.  I was a little confused by the dependency appearing in many poms and all of the other dependencies exclude the version, does that mean the latest is being used in some poms and this specific one being used in the top level pom?

I have deployed this on my machine and was still able to deposit and retrieve after the upgrade.