### PR TITLE
#RSS044-65 Updated generatePureData.sh so it now accepts additional p…

### DIFF
--- a/datavault-assembly/src/datavault-home/bin/generatePureData.sh
+++ b/datavault-assembly/src/datavault-home/bin/generatePureData.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-/usr/bin/curl "https://www.pure.ed.ac.uk/ws/api/59/persons?apiKey=$1&fields=ids.id&size=20000" > $2/purePerson.xml
-/usr/bin/perl $HOME/datavault-home/bin/parsePerson.pl -xmlFile $2/purePerson.xml > $2/person.flat
-/bin/rm $2/purePerson.xml
+/usr/bin/curl "https://$1.pure.ed.ac.uk/ws/api/$2/persons?apiKey=$3&fields=ids.id&size=20000" > $4/purePerson.xml
+/usr/bin/perl $HOME/datavault-home/bin/parsePerson.pl -xmlFile $4/purePerson.xml > $4/person.flat
+/bin/rm $4/purePerson.xml
 
-/usr/bin/curl "https://www.pure.ed.ac.uk/ws/api/59/datasets?apiKey=$1&fields=title,personAssociations.personAssociation.person.uuid,workflow&size=10000" > $2/pureDatasetDisplay.xml
-/usr/bin/perl $HOME/datavault-home/bin/parseDatasetDisplay.pl -xmlfile $2/pureDatasetDisplay.xml > $2/datasetDisplay.flat
-/bin/rm $2/pureDatasetDisplay.xml
+/usr/bin/curl "https://$1.pure.ed.ac.uk/ws/api/$2/datasets?apiKey=$3&fields=title,personAssociations.personAssociation.person.uuid,workflow&size=10000" > $4/pureDatasetDisplay.xml
+/usr/bin/perl $HOME/datavault-home/bin/parseDatasetDisplay.pl -xmlfile $4/pureDatasetDisplay.xml > $4/datasetDisplay.flat
+/bin/rm $4/pureDatasetDisplay.xml
 
-/usr/bin/curl "https://www.pure.ed.ac.uk/ws/api/59/datasets?apiKey=$1&size=10000" > $2/pureDatasetFull.xml
-/usr/bin/perl $HOME/datavault-home/bin/parseDatasetFull.pl -xmlfile $2/pureDatasetFull.xml > $2/datasetFull.flat
-/bin/rm $2/pureDatasetFull.xml
+/usr/bin/curl "https://$1.pure.ed.ac.uk/ws/api/$2/datasets?apiKey=$3&size=10000" > $4/pureDatasetFull.xml
+/usr/bin/perl $HOME/datavault-home/bin/parseDatasetFull.pl -xmlfile $4/pureDatasetFull.xml > $4/datasetFull.flat
+/bin/rm $4/pureDatasetFull.xml
 


### PR DESCRIPTION
…arams for live / test and version of API

1) Updated the script so that it now accepts 4 params

$1 www or www-test
$2 API version e.g. 59 512 ...
$3 API key (previously $1)
$4 Output dir (previously $2)

Obviously there is no validation or value checking or anything you can run with something like

/home/lacdv/datavault-home/bin/generatePureData.sh www-test 512 xxxxx-my-api-key-xxxxx /home/lacdv/pure-test
/home/lacdv/datavault-home/bin/generatePureData.sh www 512 xxxxx-my-api-key-xxxxx /home/lacdv/pure

Now we can make the live deployment cron use the live PURE and the demo one test.  We can also change the api version in the cron / command when required (RSS044-96).