### PR TITLE
Quick Fix Audit

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/scheduled/AuditDepositsChunks.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/scheduled/AuditDepositsChunks.java
@@ -57,7 +57,6 @@ public class AuditDepositsChunks {
 
     public void setSender(Sender sender) { this.sender = sender; }
 
-    @Scheduled(cron = "${cron.expression}")
     public void execute() throws Exception {
         Date now = new Date();
         System.out.println("Start Audit Job "+now.toString());

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/DepositsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/DepositsService.java
@@ -112,6 +112,9 @@ public class DepositsService {
         logger.debug("MONTH: "+getAuditPeriodMonths());
         logger.debug("YEAR: "+getAuditPeriodYears());
 
+        logger.debug("Max per Deposit: "+maxChunkAuditPerDeposit);
+        logger.debug("Total Max: "+maxChunkPerAudit);
+
         Calendar cal = Calendar.getInstance();
         cal.add(Calendar.MINUTE, -getAuditPeriodMinutes()); // to get previous days
         cal.add(Calendar.HOUR, -getAuditPeriodHours()); // to get previous days
@@ -127,6 +130,7 @@ public class DepositsService {
 
         int totalCount = 0;
         for(Deposit deposit : deposits){
+            logger.debug("Total Count: "+totalCount);
             logger.debug("check deposit: "+deposit.getID());
 
             List<DepositChunk> depositChunks = deposit.getDepositChunks();
@@ -148,6 +152,7 @@ public class DepositsService {
 
             int count = 0;
             for(DepositChunk chunk : depositChunks){
+                logger.debug("Chunk in deposit count: "+count);
                 if(totalCount >= maxChunkPerAudit) {
                     logger.debug("maxChunkPerAudit reached");
                     return chunksToAudit;
@@ -163,6 +168,7 @@ public class DepositsService {
                 if(lastAuditChunkInfo == null){
                     logger.debug("add chunk, No previous audit.");
                     chunksToAudit.add(chunk);
+                    count++; totalCount++;
                 }else if( lastAuditChunkInfo.getTimestamp().before(olderThanDate) && (
                                 lastAuditChunkInfo.getStatus().equals(AuditChunkStatus.Status.COMPLETE) ||
                                         lastAuditChunkInfo.getStatus().equals(AuditChunkStatus.Status.FIXED) ) ){

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/MultiLocalFileSystem.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/MultiLocalFileSystem.java
@@ -1,0 +1,163 @@
+package org.datavaultplatform.common.storage.impl;
+
+import org.apache.commons.io.FileUtils;
+import org.datavaultplatform.common.io.FileCopy;
+import org.datavaultplatform.common.io.Progress;
+import org.datavaultplatform.common.model.FileInfo;
+import org.datavaultplatform.common.storage.ArchiveStore;
+import org.datavaultplatform.common.storage.Device;
+import org.datavaultplatform.common.storage.UserStore;
+import org.datavaultplatform.common.storage.Verify;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class MultiLocalFileSystem extends Device implements ArchiveStore {
+
+    private String rootPath = null;
+
+    public MultiLocalFileSystem(String name, Map<String,String> config) throws FileNotFoundException {
+        super(name, config);
+        
+        // Unpack the config parameters (in an implementation-specific way)
+        rootPath = config.get("rootPath");
+
+        super.multipleCopies = true;
+
+        String[] locationsArray = rootPath.split(",");
+
+        locations = new ArrayList<String>();
+
+        for(String location : locationsArray){
+            // Verify parameters are correct.
+            File file = new File(location);
+            if (!file.exists()) {
+                throw new FileNotFoundException(location);
+            }
+            locations.add(location);
+        }
+    }
+
+    @Override
+    public long getUsableSpace() throws Exception {
+        long usageSpace = 0;
+        for(int i = 0; i < locations.size(); i++) {
+            String location = locations.get(i);
+            File file = new File(location);
+            usageSpace += file.getUsableSpace();
+        }
+        return usageSpace;
+    }
+
+    @Override
+    public void retrieve(String path, File working, Progress progress) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void retrieve(String path, File working, Progress progress, String location) throws Exception {
+        // @TODO: copy from location
+        Path absolutePath = getAbsolutePath(path, location);
+        File file = absolutePath.toFile();
+
+        if (file.isFile()) {
+            FileCopy.copyFile(progress, file, working);
+        } else if (file.isDirectory()) {
+            FileCopy.copyDirectory(progress, file, working);
+        }
+    }
+
+    @Override
+    public String store(String path, File working, Progress progress) throws Exception {
+        System.out.println("Storing: "+working.toString());
+        System.out.println("Nb of location: "+locations.size());
+        for(int i = 0; i < locations.size(); i++){
+            String location = locations.get(i);
+            System.out.println("location: "+location);
+            Path absolutePath = getAbsolutePath(path, location);
+            File retrieveFile = absolutePath.resolve(working.getName()).toFile();
+
+            if (working.isFile()) {
+                FileCopy.copyFile(progress, working, retrieveFile);
+            } else if (working.isDirectory()) {
+                FileCopy.copyDirectory(progress, working, retrieveFile);
+            }
+        }
+
+        return working.getName();
+    }
+    
+    @Override
+    public Verify.Method getVerifyMethod() {
+        // Return the default verification method (copy back and check)
+        return verificationMethod;
+    }
+    
+    private Path getAbsolutePath(String filePath, String location) {
+
+        // Join the requested path to the root of the filesystem.
+        // In future this path handling should be part of a filesystem-specific driver.
+        Path base = Paths.get(location);
+        Path absolute;
+        
+        try {
+            if (filePath.equals("")) {
+                absolute = base;
+            } else {
+                // A leading '/' would cause the path to be treated as absolute
+                while (filePath.startsWith("/")) {
+                    filePath = filePath.replaceFirst("/", "");
+                }
+
+                absolute = base.resolve(filePath);
+                absolute = Paths.get(absolute.toFile().getCanonicalPath());
+            }
+
+            if (isValidSubPath(absolute, location)) {
+                return absolute;
+            } else {
+                // Path is invalid (doesn't exist in base)!
+                return null;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+    
+    private boolean isValidSubPath(Path path, String location) {
+
+        // Check if the path is valid with respect to the base path.
+        // For example, we don't want to allow path traversal ("../../abc").
+        
+        try {
+            Path base = Paths.get(location);
+            Path canonicalBase = Paths.get(base.toFile().getCanonicalPath());
+            Path canonicalPath = Paths.get(path.toFile().getCanonicalPath());
+            
+            if (canonicalPath.startsWith(canonicalBase)) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+    
+    @Override
+    public void delete(String path, File working, Progress progress, String location) throws Exception {
+        Path absolutePath = getAbsolutePath(path, location);
+        Files.deleteIfExists(absolutePath);
+    }
+}

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/archivestores/index.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/archivestores/index.ftl
@@ -42,6 +42,7 @@
                                 <option value="AmazonGlacier">Amazon Glacier</option>
                                 <option value="DropboxFileSystem">Dropbox File System</option>
                                 <option value="LocalFileSystem">Local File System</option>
+                                <option value="MultiLocalFileSystem">Multi Local File System</option>
                                 <option value="OracleObjectStorageClassic">Oracle Object Storage Classic</option>
                                 <option value="S3Cloud">S3 Cloud</option>
                                 <option value="SFTPFileSystem">SFTP File System</option>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/index.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/index.ftl
@@ -12,6 +12,7 @@
             Current Vaults
             <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip" 
                 title="Vaults of which you are either the Owner or the Nominated Data Manager. If you think a vault is missing from this list, please contact the Research Data Service">
+            </span>
         </h3>
         
         <div class="row">
@@ -71,6 +72,7 @@
                             <small>
                                 <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip" 
                                     title="Multiple deposits may be made into one vault. Usually one vault will correspond to one Pure record">
+                                </span>
                             </small>
                         </h2>
                         

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Audit.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Audit.java
@@ -72,6 +72,10 @@ public class Audit extends Task {
         Device archiveFs = this.setupArchiveFileStores();
 
         try {
+            eventStream.send(new UpdateProgress(this.jobID, null, 0,
+                    this.depositChunkToAudit.size(), "Starting auditing ...")
+                    .withUserId(this.userID));
+
             if (archiveFs.hasMultipleCopies()) {
                 this.multipleCopies(context, archiveFs);
             } else {
@@ -90,7 +94,7 @@ public class Audit extends Task {
 
         List<String> locations = archiveFs.getLocations();
         Iterator<String> locationsIt = locations.iterator();
-        LOCATION:
+
         while (locationsIt.hasNext()) {
             String location = locationsIt.next();
             logger.info("Current " + location);
@@ -98,26 +102,13 @@ public class Audit extends Task {
                 logger.info("Attempting audit on archive from " + location);
                 this.doAudit(context, archiveFs, false, location);
                 logger.info("Completed audit on archive from " + location);
-                break LOCATION;
             } catch (Exception e) {
-                // if last location has an error throw the error else go
-                // round again
-                if (!locationsIt.hasNext()) {
-                    logger.info("All locations had problems throwing exception " + e.getMessage());
-                    throw e;
-                } else {
-                    logger.info("Current " + location + " has a problem trying next location");
-                    continue LOCATION;
-                }
+                logger.info("Current " + location + " has a problem trying next location");
             }
         }
     }
 
     private void doAudit(Context context, Device archiveFs, boolean singleCopy, String location) {
-        eventStream.send(new UpdateProgress(this.jobID, null, 0,
-                this.depositChunkToAudit.size(), "Starting auditing ...")
-                .withUserId(this.userID));
-
         logger.info("Retrieving " + depositChunkToAudit.size() + " chunk(s) for audit.");
 
         for(int i = 0; i < depositChunkToAudit.size(); i++) {

--- a/docker/tmp/datavault/archiveBis/.gitignore
+++ b/docker/tmp/datavault/archiveBis/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Fix several issues noticed during first run of the audit on Demo:
1) Job running twice in quick succession:
Caused by Scheduled annotion which cause the bean to be created twice
2) The second TSM location wasn't checked by audit:
I've added MultiLocalFileSystem storage so we can test multi storage on
our machine and use it to fix this issue.
3) The total chunk per audit set in properties was ignored