### PR TITLE
IssueID #RSS044-180 Fix the available roles for users with school level permissions

### DIFF
--- a/datavault-common/src/main/java/org/datavaultplatform/common/util/RoleUtils.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/util/RoleUtils.java
@@ -72,6 +72,9 @@ public class RoleUtils {
             if (rm.getType().equals(RoleType.ADMIN)) {
                 admin = true;
             }
+            if (rm.getType().equals(RoleType.SCHOOL)) {
+                admin = true;
+            }
         }
 
         // iterate over the roles and remove any with a higher or equal status


### PR DESCRIPTION
1) Updated RoleUtils.getAssignableRoles so that users with school level permissions now have a list of vault permissions when they try to assign vault roles.