### PR TITLE
IssueID #RSS044-181 Fix the silent addition of the new users so that their email is provided

### DIFF
--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/LDAPService.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/LDAPService.java
@@ -161,7 +161,7 @@ public class LDAPService {
         SearchRequest searchRequest = createSearchRequest(
                 "(uid="  + uid + ")" ,
                 1,
-                "uid", "cn", "email", "eduniRefNo");
+                "uid", "cn", "mail", "eduniRefNo");
     
         // We don't want this to take too long as it might, default is 30s
         connection.setTimeOut(5000);


### PR DESCRIPTION
1) Updated LDAPService.getLdapUserInfo so that we ask for the mail field rather than email (which doesn't exist)