### PR TITLE
IssueID #RSS044-185 Add config values to set number of TSM / Oracle retries

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/DepositsController.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/DepositsController.java
@@ -45,6 +45,8 @@ public class DepositsController {
     private String awsSecretKey;
     private String tsmRetryTime;
     private String occRetryTime;
+    private String tsmMaxRetries;
+    private String occMaxRetries;
 
     private static final Logger logger = LoggerFactory.getLogger(DepositsController.class);
     
@@ -122,6 +124,14 @@ public class DepositsController {
 
     public void setOccRetryTime(String occRetryTime) {
         this.occRetryTime = occRetryTime;
+    }
+
+    public void setTsmMaxRetries(String tsmMaxRetries) {
+        this.tsmMaxRetries = tsmMaxRetries;
+    }
+
+    public void setOccMaxRetries(String occMaxRetries) {
+        this.occMaxRetries = occMaxRetries;
     }
 
     @RequestMapping(value = "/deposits/{depositid}", method = RequestMethod.GET)
@@ -391,6 +401,9 @@ public class DepositsController {
 		        	if (this.tsmRetryTime != null && ! this.tsmRetryTime.equals("")) {
 		        	    asProps.put("tsmRetryTime", this.tsmRetryTime);
                     }
+                    if (this.tsmMaxRetries != null && ! this.tsmMaxRetries.equals("")) {
+                        asProps.put("tsmMaxRetries", this.tsmMaxRetries);
+                    }
 		        	archiveStore.setProperties(asProps);
 		        }
 
@@ -398,6 +411,9 @@ public class DepositsController {
                     HashMap<String, String> asProps = archiveStore.getProperties();
                     if (this.occRetryTime != null && ! this.occRetryTime.equals("")) {
                         asProps.put("occRetryTime", this.occRetryTime);
+                    }
+                    if (this.occMaxRetries != null && ! this.occMaxRetries.equals("")) {
+                        asProps.put("occMaxRetries", this.occMaxRetries);
                     }
                     archiveStore.setProperties(asProps);
                 }

--- a/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
@@ -71,7 +71,9 @@
         <property name="sender" ref="sender" />
         <property name="optionsDir" value="${optionsDir:#{null}}" />
         <property name="tsmRetryTime" value="${tsmRetryTime:#{null}}" />
+        <property name="tsmMaxRetries" value="${tsmMaxRetries:#{null}}" />
         <property name="occRetryTime" value="${occRetryTime:#{null}}" />
+        <property name="occMaxRetries" value="${occMaxRetries:#{null}}" />
         <property name="tempDir" value="${tempDir:#{null}}" />
         <property name="bucketName" value="${s3.bucketName:#{null}}" />
         <property name="region" value="${s3.region:#{null}}" />


### PR DESCRIPTION
1) Added new properties to datavault-broker-servlet.xml for DepositsController
2) Updated DepositsController to have new tsmMaxRetries and occMaxRetries members along with setter
3) Updated DepositsController so that the new members are populated if the config is present.
4) Updated the Oracle and TSM plugins so that if present the new number of retries values are used.