### PR TITLE
IssueID #RSS044-166 Add config values to set number of TSM / Oracle retries

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/scheduled/AuditDepositsChunks.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/scheduled/AuditDepositsChunks.java
@@ -24,6 +24,10 @@ public class AuditDepositsChunks {
     private String region;
     private String awsAccessKey;
     private String awsSecretKey;
+    private String tsmRetryTime;
+    private String occRetryTime;
+    private String tsmMaxRetries;
+    private String occMaxRetries;
 
     public void setDepositsService(DepositsService depositsService) {
         this.depositsService = depositsService;
@@ -54,7 +58,16 @@ public class AuditDepositsChunks {
     public void setAwsSecretKey(String awsSecretKey) {
         this.awsSecretKey = awsSecretKey;
     }
-
+    public void setTsmRetryTime(String tsmRetryTime) {
+        this.tsmRetryTime = tsmRetryTime;
+    }
+    public void setOccRetryTime(String occRetryTime) {
+        this.occRetryTime = occRetryTime;
+    }
+    public void setTsmMaxRetries(String tsmMaxRetries) { this.tsmMaxRetries = tsmMaxRetries; }
+    public void setOccMaxRetries(String occMaxRetries) {
+        this.occMaxRetries = occMaxRetries;
+    }
     public void setSender(Sender sender) { this.sender = sender; }
 
     public void execute() throws Exception {
@@ -161,6 +174,23 @@ public class AuditDepositsChunks {
                     }
                     if (this.tempDir != null && ! this.tempDir.equals("")) {
                         asProps.put("tempDir", this.tempDir);
+                    }
+                    if (this.tsmRetryTime != null && ! this.tsmRetryTime.equals("")) {
+                        asProps.put("tsmRetryTime", this.tsmRetryTime);
+                    }
+                    if (this.tsmMaxRetries != null && ! this.tsmMaxRetries.equals("")) {
+                        asProps.put("tsmMaxRetries", this.tsmMaxRetries);
+                    }
+                    archiveStore.setProperties(asProps);
+                }
+
+                if (archiveStore.getStorageClass().equals("org.datavaultplatform.common.storage.impl.OracleObjectStorageClassic")) {
+                    HashMap<String, String> asProps = archiveStore.getProperties();
+                    if (this.occRetryTime != null && ! this.occRetryTime.equals("")) {
+                        asProps.put("occRetryTime", this.occRetryTime);
+                    }
+                    if (this.occMaxRetries != null && ! this.occMaxRetries.equals("")) {
+                        asProps.put("occMaxRetries", this.occMaxRetries);
                     }
                     archiveStore.setProperties(asProps);
                 }

--- a/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-root.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-root.xml
@@ -158,6 +158,10 @@
         <property name="auditsService" ref="auditsService" />
         <property name="sender" ref="sender" />
         <property name="optionsDir" value="${optionsDir:#{null}}" />
+        <property name="tsmRetryTime" value="${tsmRetryTime:#{null}}" />
+        <property name="tsmMaxRetries" value="${tsmMaxRetries:#{null}}" />
+        <property name="occRetryTime" value="${occRetryTime:#{null}}" />
+        <property name="occMaxRetries" value="${occMaxRetries:#{null}}" />
         <property name="tempDir" value="${tempDir:#{null}}" />
         <property name="bucketName" value="${s3.bucketName:#{null}}" />
         <property name="region" value="${s3.region:#{null}}" />


### PR DESCRIPTION
I finally realised why the auditing wasn't picking up the TSM / Oracle holding params (the deposits controller passes the config to the plugin but I hadn't added that to the AuditDepositsChunks class) once I did that it now works.

I've already tested this on demo.

1) Added the params to the bean in datavault-broker-root.xml
2) Updated AuditDepositChunks.java to have new members / setters and updated the config setter class to include the new params.