### PR TITLE
IssueID #RSS044-197 Add new config option to give increased max deposit size for Admins.

### DIFF
--- a/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-servlet.xml
@@ -38,8 +38,10 @@
     <bean id="filesController" class="org.datavaultplatform.broker.controllers.FilesController">
         <property name="filesService" ref="filesService" />
         <property name="usersService" ref="usersService" />
+        <property name="adminService" ref="adminService" />
         <property name="tempDir" value="${tempDir}" />
         <property name="maxDepositByteSize" value="${max.deposit.size}"/>
+        <property name="maxAdminDepositByteSize" value="${max.admin.deposit.size}"/>
     </bean>
 
     <bean id="vaultsController" class="org.datavaultplatform.broker.controllers.VaultsController">

--- a/datavault-common/src/main/java/org/datavaultplatform/common/response/DepositSize.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/response/DepositSize.java
@@ -1,0 +1,30 @@
+package org.datavaultplatform.common.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.jsondoc.core.annotation.ApiObject;
+import org.jsondoc.core.annotation.ApiObjectField;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@ApiObject(name = "DepositSize")
+public class DepositSize {
+    @ApiObjectField(description = "The max deposit size allowed")
+    private Long max;
+    @ApiObjectField(description = "Whether the potential deposit is under the limit")
+    private Boolean result;
+
+    public Long getMax() {
+        return this.max;
+    }
+
+    public void setMax(Long max) {
+        this.max = max;
+    }
+
+    public Boolean getResult() {
+        return this.result;
+    }
+
+    public void setResult(Boolean result) {
+        this.result = result;
+    }
+}

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/FilesController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/FilesController.java
@@ -2,6 +2,7 @@ package org.datavaultplatform.webapp.controllers;
 
 import org.datavaultplatform.common.io.FileUtils;
 import org.datavaultplatform.common.model.FileInfo;
+import org.datavaultplatform.common.response.DepositSize;
 import org.datavaultplatform.webapp.model.FancytreeNode;
 import org.datavaultplatform.webapp.services.RestService;
 import java.util.ArrayList;
@@ -15,19 +16,9 @@ import org.apache.commons.codec.binary.Base64;
 public class FilesController {
 
     private RestService restService;
-    private Long maxDepositByteSize;
     
     public void setRestService(RestService restService) {
         this.restService = restService;
-    }
-
-    public void setMaxDepositByteSize(String maxDepositByteSize) {
-        long bytes = FileUtils.parseFormattedSizeToBytes(maxDepositByteSize);
-        this.maxDepositByteSize = bytes;
-    }
-
-    public String getMaxDepositSizeDisplay(){
-        return FileUtils.getGibibyteSizeStr(maxDepositByteSize);
     }
 
     public ArrayList<FancytreeNode> getNodes(String parent, boolean directoryOnly) throws Exception{
@@ -100,9 +91,10 @@ public class FilesController {
             System.out.println("filePaths: " + filePath);
         }
 
-        String success = restService.checkDepositSize(filePaths).toString();
-        String max = getMaxDepositSizeDisplay();
-
+        DepositSize result = restService.checkDepositSize(filePaths);
+        Boolean success = result.getResult();
+        String max = FileUtils.getGibibyteSizeStr(result.getMax());
+        System.out.println("Max deposit (web): " + max);
         return "{ \"success\":\"" + success + "\", \"max\":\"" + max + "\"}";
     }
     

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/RestService.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/RestService.java
@@ -137,7 +137,7 @@ public class RestService {
         return (String)response.getBody();
     }
 
-    public Boolean checkDepositSize(String[] filePaths) {
+    public DepositSize checkDepositSize(String[] filePaths) {
 
         String parameters = "?";
 
@@ -151,11 +151,11 @@ public class RestService {
 
         System.out.println("parameters: " + parameters);
 
-        HttpEntity<?> response = get(brokerURL + "/checkdepositsize" + parameters, Boolean.class);
+        HttpEntity<?> response = get(brokerURL + "/checkdepositsize" + parameters, DepositSize.class);
 
         System.out.println("return: " + response.getBody());
 
-        return (Boolean)response.getBody();
+        return (DepositSize) response.getBody();
     }
 
     public VaultInfo[] getVaultsListing() {

--- a/datavault-webapp/src/main/webapp/WEB-INF/datavault-webapp-servlet.xml
+++ b/datavault-webapp/src/main/webapp/WEB-INF/datavault-webapp-servlet.xml
@@ -99,7 +99,6 @@
 
     <bean id="filesController" class="org.datavaultplatform.webapp.controllers.FilesController">
         <property name="restService" ref="restService" />
-        <property name="maxDepositByteSize" value="${max.deposit.size}"/>
     </bean>
 
     <bean id="depositsController" class="org.datavaultplatform.webapp.controllers.DepositsController">


### PR DESCRIPTION

1) Removed injection of max.deposit.size param from webapp FilesController
2) Injected max.admin.deposit.size param into broker FilesController
3) Injected adminService into broker FilesController
4) Updated broker FilesController.checkDepositSize to use the new param to set the correct max deposit size
5) Also updated it to return a helper object with the result of the check and the max value ( so we can remove the duplicate code to get the max value in the web FilesController)
6) Added new DepositSize class to act as the helper object
7) Removed the redundant max deposit size code from the webapp FilesController and updated the call to the API to expect the new return value
8) Updated RestService to expect the new return value
9) Added the new param to the default and docker datavault.properties (max.admin.deposit.size)