### PR TITLE
IssueID #RSS044-198 Fix snapshot bug that caused Vault creation to fail if dataset metadata contained new lines

### DIFF
--- a/datavault-assembly/src/datavault-home/bin/parseDatasetFull.pl
+++ b/datavault-assembly/src/datavault-home/bin/parseDatasetFull.pl
@@ -19,5 +19,6 @@ foreach my $dataset ($dom->findnodes('/result/items/dataSet')) {
    my $ds = $dataset->findnodes('./@uuid')->to_literal();
    my $crisID = $dataset->findnodes('./@pureId')->to_literal();
    my $title = $dataset->findnodes('./title')->to_literal();
+   $dataset =~ s/\n//g;
    print $ds . "\t" . $title . "\t" . $dataset . "\t" . $crisID . "\n";
 }


### PR DESCRIPTION
1) Updated parseDatasetFull.pl so that the metadata now has all new lines stripped if any are present.