### PR TITLE
Ds rss044 update spring to latest v4

### DIFF
--- a/datavault-broker/pom.xml
+++ b/datavault-broker/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.18</version>
+            <version>1.20</version>
         </dependency>
 
         <dependency>

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/ApiErrorHandler.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/ApiErrorHandler.java
@@ -44,7 +44,7 @@ public class ApiErrorHandler extends DefaultResponseErrorHandler {
         super.handleError(response);
     }
 
-    private Charset getCharset(ClientHttpResponse response) {
+    protected Charset getCharset(ClientHttpResponse response) {
         HttpHeaders headers = response.getHeaders();
         MediaType contentType = headers.getContentType();
         return contentType != null ? contentType.getCharset() : null;

--- a/datavault-worker/pom.xml
+++ b/datavault-worker/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.18</version>
+            <version>1.20</version>
         </dependency>
 
         <dependency>

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -44,7 +44,7 @@
       "dev": true,
       "requires": {
         "debug": "^3.1.0",
-        "lodash.once": "^4.1.1"
+        "lodash.once": "^4.17.12"
       }
     },
     "@types/blob-util": {

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
     </modules>
 
     <properties>
-        <spring.version>4.3.1.RELEASE</spring.version>
-        <spring-security.version>4.0.2.RELEASE</spring-security.version>
+        <spring.version>4.3.26.RELEASE</spring.version>
+        <spring-security.version>4.2.14.RELEASE</spring-security.version>
         <spring-rabbit.version>1.4.5.RELEASE</spring-rabbit.version>
         <hibernate.version>4.3.10.Final</hibernate.version>
         <hibernate-validator.version>4.3.2.Final</hibernate-validator.version>
@@ -219,6 +219,8 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
+                <!-- <version>2.10.2</version> -->
+                <!-- <version>2.8.11.5</version> -->
                 <version>2.7.9.4</version>
             </dependency>
 


### PR DESCRIPTION
We've been putting off upgrading to Spring MVC 5 and Spring Security 5 but I noticed that both version 4s are still being maintained with recent releases.  I've updated most of the dependencies that were complaining with the latest releases.  There were a couple that didn't go that simply we can look at them another time.