### PR TITLE
Off ticket tweak to fix the docker deploy on my IMac

### DIFF
--- a/broker.Dockerfile
+++ b/broker.Dockerfile
@@ -29,5 +29,5 @@ RUN chown -R datavault:datavault ${CATALINA_HOME}
 WORKDIR ${CATALINA_HOME}
 EXPOSE 8080
 
-ENTRYPOINT ["/docker_datavault-home/scripts/docker-entrypoint.sh", "brocker"]
+ENTRYPOINT ["/docker_datavault-home/scripts/docker-entrypoint.sh", "broker"]
 CMD ["/usr/local/tomcat/bin/catalina.sh", "run"]

--- a/docker/scripts/docker-entrypoint.sh
+++ b/docker/scripts/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/sh
 
 set -e
 

--- a/docker/scripts/set-defaults.sh
+++ b/docker/scripts/set-defaults.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 export BROKER_HOST=${BROKER_HOST:-broker}
 export MYSQL_HOST=${MYSQL_HOST:-mysql}
 export MYSQL_PASSWORD=${MYSQL_PASSWORD:-datavault}


### PR DESCRIPTION
A couple of days ago the docker deploy stopped working on my machine for some reason.  I found stuff on the web that suggested that Alpine doesn't work with /bin/bash but does with /bin/sh.
I changed all the docker deployment scripts to use this and it started working again. I dunno why it suddenly changed or why it ever worked!

If this causes issues elsewhere we can easily revert.