### PR TITLE
RSS212-99 - Fix the email for ownership transfer

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/VaultsController.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/VaultsController.java
@@ -165,9 +165,12 @@ public class VaultsController {
 
             eventService.addEvent(orphanVaultEvent);
         } else {
+            String previousUserID = vault.getUser().getID();
+
             vaultsService.transferVault(vault, usersService.getUser(transfer.getUserId()), transfer.getReason());
 
-            sendEmails("transfer-vault-ownership.vm", vault, userID, transfer.getUserId());
+            logger.debug("send email for transfer ownership from: "+previousUserID+" to "+transfer.getUserId());
+            sendEmails("transfer-vault-ownership.vm", vault, previousUserID, transfer.getUserId());
 
             TransferVaultOwnership transferEvent = new TransferVaultOwnership(transfer, vault, userID);
             transferEvent.setVault(vault);


### PR DESCRIPTION
The wrong previous owner id was showing in the email.
We were using the user who did the transfer instead of the previous
owner.