### PR TITLE
RSS212-106 Add threads to increase performance

### DIFF
--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/OracleObjectStorageClassic.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/OracleObjectStorageClassic.java
@@ -5,7 +5,8 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
+//import java.util.concurrent.atomic.AtomicReference;
 
 import org.datavaultplatform.common.io.Progress;
 import org.datavaultplatform.common.storage.ArchiveStore;
@@ -126,6 +127,64 @@ public class OracleObjectStorageClassic extends Device implements ArchiveStore {
 	public String store(String depositId, File working, Progress progress) throws Exception {
 		for (int r = 0; r < OracleObjectStorageClassic.maxRetries; r++) {
 			try {
+
+//				TivoliStorageManager.TSMTracker loc1 = new TivoliStorageManager.TSMTracker();
+//				loc1.setLocation("loc1");
+//				Thread loc1Thread = new Thread(loc1);
+//				final AtomicReference throwableReference = new AtomicReference<Throwable>();
+//				loc1Thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+//					public void uncaughtException(Thread t, Throwable e) {
+//						throwableReference.set(e);
+//					}
+//				});
+//				loc1Thread.start();
+//				TivoliStorageManager.TSMTracker loc2 = new TivoliStorageManager.TSMTracker();
+//				loc2.setLocation("loc2");
+//				Thread loc2Thread = new Thread(loc2);
+//				loc2Thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+//					public void uncaughtException(Thread t, Throwable e) {
+//						throwableReference.set(e);
+//					}
+//				});
+//				loc2Thread.start();
+//
+//				while (loc1Thread.isAlive() && loc2Thread.isAlive()) {
+//					TimeUnit.MINUTES.sleep(1);
+//				}
+//
+//				Throwable throwable = (Throwable)throwableReference.get();
+//				if (throwable != null) {
+//					if (throwable instanceof Exception) {
+//						throw (Exception) throwable;
+//					} else if (throwable instanceof RuntimeException) {
+//						throw (RuntimeException)throwable;
+//					}
+//				}
+
+//				ExecutorService executor = Executors.newSingleThreadExecutor();
+//				TivoliStorageManager.TSMTrackerToo loc1 = new TivoliStorageManager.TSMTrackerToo();
+//				loc1.setLocation("loc1");
+//				TivoliStorageManager.TSMTrackerToo loc2 = new TivoliStorageManager.TSMTrackerToo();
+//				loc2.setLocation("loc2");
+//				Future<Void> loc1Future = executor.submit(loc1);
+//				Future<Void> loc2Future = executor.submit(loc2);
+//
+//				executor.shutdown();
+//				try {
+//					loc1Future.get();
+//					loc2Future.get();
+//					logger.info("loc1 result " + loc1.result);
+//					logger.info("loc2 result " + loc2.result);
+//				} catch (ExecutionException ee) {
+//					Throwable cause = ee.getCause();
+//					if (cause instanceof Exception) {
+//						logger.info("Upload failed. " + cause.getMessage());
+//						throw (Exception) cause;
+//					}
+//				}
+
+
+
 				String containerName = this.getContainerName();
 				this.manager = FileTransferManager.getDefaultFileTransferManager(this.getTransferAuth());
 				UploadConfig uploadConfig = new UploadConfig();

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
@@ -197,12 +197,12 @@ public class TivoliStorageManager extends Device implements ArchiveStore {
 //		}
 
 		ExecutorService executor = Executors.newSingleThreadExecutor();
-		TivoliStorageManager.TSMTrackerToo loc1 = new TivoliStorageManager.TSMTrackerToo();
+		TivoliStorageManager.TSMTracker loc1 = new TivoliStorageManager.TSMTracker();
 		loc1.setLocation(TivoliStorageManager.TSM_SERVER_NODE1_OPT);
 		loc1.setWorking(tsmFile);
 		loc1.setProgress(progress);
 		loc1.setDescription(depositId);
-		TivoliStorageManager.TSMTrackerToo loc2 = new TivoliStorageManager.TSMTrackerToo();
+		TivoliStorageManager.TSMTracker loc2 = new TivoliStorageManager.TSMTracker();
 		loc2.setLocation(TivoliStorageManager.TSM_SERVER_NODE1_OPT);
 		loc2.setWorking(tsmFile);
 		loc2.setProgress(progress);
@@ -219,7 +219,7 @@ public class TivoliStorageManager extends Device implements ArchiveStore {
 		} catch (ExecutionException ee) {
 			Throwable cause = ee.getCause();
 			if (cause instanceof Exception) {
-				logger.info("Upload failed. " + cause.getMessage());
+				logger.info("TSM upload failed. " + cause.getMessage());
 				throw (Exception) cause;
 			}
 		}
@@ -312,30 +312,30 @@ public class TivoliStorageManager extends Device implements ArchiveStore {
     	}
     }
 
-	protected static class TSMTracker implements Runnable {
+//	protected static class TSMTracker implements Runnable {
+//
+//		private String location;
+//
+//		@Override
+//		public void run() {
+//			// do stuff
+//			//String test = null;
+//			logger.debug("Starting: " + this.getLocation());
+//			//logger.debug("Force error: " + test.length());
+//			//throw new Exception("Bad TSM stuff");
+//		}
+//
+//
+//		public String getLocation() {
+//			return this.location;
+//		}
+//
+//		public void setLocation(String location) {
+//			this.location = location;
+//		}
+//	}
 
-		private String location;
-
-		@Override
-		public void run() {
-			// do stuff
-			//String test = null;
-			logger.debug("Starting: " + this.getLocation());
-			//logger.debug("Force error: " + test.length());
-			//throw new Exception("Bad TSM stuff");
-		}
-
-
-		public String getLocation() {
-			return this.location;
-		}
-
-		public void setLocation(String location) {
-			this.location = location;
-		}
-	}
-
-	protected static class TSMTrackerToo implements Callable {
+	protected static class TSMTracker implements Callable {
 
     	private String location;
     	private File working;

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
@@ -162,48 +162,14 @@ public class TivoliStorageManager extends Device implements ArchiveStore {
     	}
     	File tsmFile = new File(pathPrefix + "/" + depositId + "/" + working.getName());
     	// thread for each node
-
-//		TSMTracker loc1 = new TSMTracker();
-//		loc1.setLocation("loc1");
-//		Thread loc1Thread = new Thread(loc1);
-//		final AtomicReference throwableReference = new AtomicReference<Throwable>();
-//		loc1Thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
-//			public void uncaughtException(Thread t, Throwable e) {
-//				throwableReference.set(e);
-//			}
-//		});
-//		loc1Thread.start();
-//		TSMTracker loc2 = new TSMTracker();
-//		loc2.setLocation("loc2");
-//		Thread loc2Thread = new Thread(loc2);
-//		loc2Thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
-//			public void uncaughtException(Thread t, Throwable e) {
-//				throwableReference.set(e);
-//			}
-//		});
-//		loc2Thread.start();
-//
-//		while (loc1Thread.isAlive() && loc2Thread.isAlive()) {
-//			TimeUnit.MINUTES.sleep(1);
-//		}
-//
-//		Throwable throwable = (Throwable)throwableReference.get();
-//		if (throwable != null) {
-//			if (throwable instanceof Exception) {
-//				throw (Exception) throwable;
-//			} else if (throwable instanceof RuntimeException) {
-//				throw (RuntimeException)throwable;
-//			}
-//		}
-
-		ExecutorService executor = Executors.newSingleThreadExecutor();
+		ExecutorService executor = Executors.newFixedThreadPool(2);
 		TivoliStorageManager.TSMTracker loc1 = new TivoliStorageManager.TSMTracker();
 		loc1.setLocation(TivoliStorageManager.TSM_SERVER_NODE1_OPT);
 		loc1.setWorking(tsmFile);
 		loc1.setProgress(progress);
 		loc1.setDescription(depositId);
 		TivoliStorageManager.TSMTracker loc2 = new TivoliStorageManager.TSMTracker();
-		loc2.setLocation(TivoliStorageManager.TSM_SERVER_NODE1_OPT);
+		loc2.setLocation(TivoliStorageManager.TSM_SERVER_NODE2_OPT);
 		loc2.setWorking(tsmFile);
 		loc2.setProgress(progress);
 		loc2.setDescription(depositId);

--- a/datavault-common/src/main/java/org/datavaultplatform/common/task/Context.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/task/Context.java
@@ -6,7 +6,6 @@ import java.nio.file.Path;
 // Some common properties needed for all jobs
 
 public class Context {
-
     public enum AESMode {GCM, CBC};
 
     private Path tempDir;
@@ -22,6 +21,7 @@ public class Context {
     private String vaultKeyName;
     private String vaultSslPEMPath;
     private Boolean multipleValidationEnabled;
+    private int noChunkThreads;
     
     public Context() {};
     public Context(Path tempDir, Path metaDir, EventStream eventStream,
@@ -29,7 +29,8 @@ public class Context {
                    Boolean encryptionEnabled, AESMode encryptionMode, 
                    String vaultAddress, String vaultToken,
                    String vaultKeyPath, String vaultKeyName,
-                   String vaultSslPEMPath, Boolean multipleValidationEnabled) {
+                   String vaultSslPEMPath, Boolean multipleValidationEnabled
+                    ,int noChunkThreads) {
         this.tempDir = tempDir;
         this.metaDir = metaDir;
         this.eventStream = eventStream;
@@ -43,6 +44,7 @@ public class Context {
         this.vaultKeyName = vaultKeyName;
         this.vaultSslPEMPath = vaultSslPEMPath;
         this.multipleValidationEnabled = multipleValidationEnabled;
+        this.noChunkThreads = noChunkThreads;
     }
 
     public Path getTempDir() {
@@ -143,5 +145,13 @@ public class Context {
 
     public void setMultipleValidationEnabled(Boolean multipleValidationEnabled) {
         this.multipleValidationEnabled = multipleValidationEnabled;
+    }
+
+    public int getNoChunkThreads() {
+        return noChunkThreads;
+    }
+
+    public void setNoChunkThreads(int noChunkThreads) {
+        this.noChunkThreads = noChunkThreads;
     }
 }

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/ChunkDownloadTracker.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/ChunkDownloadTracker.java
@@ -27,7 +27,7 @@ public class ChunkDownloadTracker implements Callable {
     private Boolean doVerification;
     private HashMap<Integer, byte[]> ivs;
     private  String[] encChunksHash;
-    private static final Logger logger = LoggerFactory.getLogger(ProgressTracker.class);
+    private static final Logger logger = LoggerFactory.getLogger(ChunkDownloadTracker.class);
 
     @Override
     public Object call() throws Exception {
@@ -42,9 +42,9 @@ public class ChunkDownloadTracker implements Callable {
         // Copy file back from the archive storage
         logger.debug("archiveChunkId: "+archiveChunkId);
         if (multipleCopies && location != null) {
-            copyBackFromArchive(archiveStore, archiveChunkId, chunkFile, location);
+            CopyBackFromArchive.copyBackFromArchive(archiveStore, archiveChunkId, chunkFile, location);
         } else {
-            copyBackFromArchive(archiveStore, archiveChunkId, chunkFile);
+            CopyBackFromArchive.copyBackFromArchive(archiveStore, archiveChunkId, chunkFile);
         }
 
         // Decryption
@@ -78,23 +78,6 @@ public class ChunkDownloadTracker implements Callable {
                 throw new Exception("checksum failed: " + chunkHash + " != " + origChunkHash);
             }
         }
-    }
-
-    private void copyBackFromArchive(ArchiveStore archiveStore, String archiveId, File tarFile) throws Exception {
-
-        this.copyBackFromArchive(archiveStore, archiveId, tarFile, null);
-    }
-
-    private void copyBackFromArchive(ArchiveStore archiveStore, String archiveId, File tarFile, String location) throws Exception {
-
-        // Ask the driver to copy files to the temp directory
-        Progress progress = new Progress();
-        if (location == null) {
-            ((Device)archiveStore).retrieve(archiveId, tarFile, progress);
-        } else {
-            ((Device)archiveStore).retrieve(archiveId, tarFile, progress, location);
-        }
-        logger.info("Copied: " + progress.dirCount + " directories, " + progress.fileCount + " files, " + progress.byteCount + " bytes");
     }
 
     public File getChunkFile() {

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/ChunkDownloadTracker.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/ChunkDownloadTracker.java
@@ -1,0 +1,187 @@
+package org.datavaultplatform.worker.operations;
+
+import org.datavaultplatform.common.crypto.Encryption;
+import org.datavaultplatform.common.io.Progress;
+import org.datavaultplatform.common.storage.ArchiveStore;
+import org.datavaultplatform.common.storage.Device;
+import org.datavaultplatform.common.storage.Verify;
+import org.datavaultplatform.common.task.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.concurrent.Callable;
+
+public class ChunkDownloadTracker implements Callable {
+
+    private File chunkFile;
+    private String chunkHash;
+    private Context context;
+    private String archiveId;
+    private Boolean multipleCopies;
+    private String location;
+    private ArchiveStore archiveStore;
+    private int count;
+    private Boolean doVerification;
+    private HashMap<Integer, byte[]> ivs;
+    private  String[] encChunksHash;
+    private static final Logger logger = LoggerFactory.getLogger(ProgressTracker.class);
+
+    @Override
+    public Object call() throws Exception {
+        // if less that max threads started start new one
+        //File chunkFile = chunkFiles[i];
+        //String chunkHash = chunksHash[i];
+        // Delete the existing temporary file
+        int chunkNum = count;
+        chunkNum++;
+        chunkFile.delete();
+        String archiveChunkId = archiveId+FileSplitter.CHUNK_SEPARATOR+(chunkNum);
+        // Copy file back from the archive storage
+        logger.debug("archiveChunkId: "+archiveChunkId);
+        if (multipleCopies && location != null) {
+            copyBackFromArchive(archiveStore, archiveChunkId, chunkFile, location);
+        } else {
+            copyBackFromArchive(archiveStore, archiveChunkId, chunkFile);
+        }
+
+        // Decryption
+        if(ivs != null) {
+
+            if(doVerification) {
+                Encryption.decryptFile(context, chunkFile, ivs.get(chunkNum));
+            } else {
+                String encChunkHash = encChunksHash[count];
+
+                // Check hash of encrypted file
+                logger.debug("Verifying encrypted chunk file: "+chunkFile.getAbsolutePath());
+                verifyChunkFile(context.getTempDir(), chunkFile, encChunkHash);
+            }
+        }
+
+        //logger.debug("Verifying chunk file: "+chunkFile.getAbsolutePath());
+        //verifyChunkFile(context.getTempDir(), chunkFile, chunkHash);
+        logger.debug("Chunk download thread completed: " + chunkNum);
+        return null;
+    }
+
+    private void verifyChunkFile(Path tempPath, File chunkFile, String origChunkHash) throws Exception {
+
+        if (origChunkHash != null) {
+            logger.info("Get Digest from: " + chunkFile.getAbsolutePath());
+            // Compare the SHA hash
+            String chunkHash = Verify.getDigest(chunkFile);
+            logger.info("Checksum: " + chunkHash);
+            if (!chunkHash.equals(origChunkHash)) {
+                throw new Exception("checksum failed: " + chunkHash + " != " + origChunkHash);
+            }
+        }
+    }
+
+    private void copyBackFromArchive(ArchiveStore archiveStore, String archiveId, File tarFile) throws Exception {
+
+        this.copyBackFromArchive(archiveStore, archiveId, tarFile, null);
+    }
+
+    private void copyBackFromArchive(ArchiveStore archiveStore, String archiveId, File tarFile, String location) throws Exception {
+
+        // Ask the driver to copy files to the temp directory
+        Progress progress = new Progress();
+        if (location == null) {
+            ((Device)archiveStore).retrieve(archiveId, tarFile, progress);
+        } else {
+            ((Device)archiveStore).retrieve(archiveId, tarFile, progress, location);
+        }
+        logger.info("Copied: " + progress.dirCount + " directories, " + progress.fileCount + " files, " + progress.byteCount + " bytes");
+    }
+
+    public File getChunkFile() {
+        return chunkFile;
+    }
+
+    public void setChunkFile(File chunkFile) {
+        this.chunkFile = chunkFile;
+    }
+
+    public String getChunkHash() {
+        return chunkHash;
+    }
+
+    public void setChunkHash(String chunkHash) {
+        this.chunkHash = chunkHash;
+    }
+
+    public Context getContext() {
+        return context;
+    }
+
+    public void setContext(Context context) {
+        this.context = context;
+    }
+
+    public String getArchiveId() {
+        return archiveId;
+    }
+
+    public void setArchiveId(String archiveId) {
+        this.archiveId = archiveId;
+    }
+
+    public Boolean getMultipleCopies() {
+        return multipleCopies;
+    }
+
+    public void setMultipleCopies(Boolean multipleCopies) {
+        this.multipleCopies = multipleCopies;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public ArchiveStore getArchiveStore() {
+        return archiveStore;
+    }
+
+    public void setArchiveStore(ArchiveStore archiveStore) {
+        this.archiveStore = archiveStore;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+    public Boolean getDoVerification() {
+        return doVerification;
+    }
+
+    public void setDoVerification(Boolean doVerification) {
+        this.doVerification = doVerification;
+    }
+
+    public HashMap<Integer, byte[]> getIvs() {
+        return ivs;
+    }
+
+    public void setIvs(HashMap<Integer, byte[]> ivs) {
+        this.ivs = ivs;
+    }
+
+    public String[] getEncChunksHash() {
+        return encChunksHash;
+    }
+
+    public void setEncChunksHash(String[] encChunksHash) {
+        this.encChunksHash = encChunksHash;
+    }
+}

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/ChunkUploadTracker.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/ChunkUploadTracker.java
@@ -1,0 +1,128 @@
+package org.datavaultplatform.worker.operations;
+
+import org.datavaultplatform.common.storage.ArchiveStore;
+import org.datavaultplatform.worker.queue.EventSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.*;
+
+public class ChunkUploadTracker implements Callable {
+
+    private File chunk;
+    private int chunkCount;
+    private HashMap<String, ArchiveStore> archiveStores = new HashMap<>();
+    private String depositId;
+    private String jobID;
+    private EventSender eventStream;
+    private File tarFile;
+    private String userID;
+    private static final Logger logger = LoggerFactory.getLogger(ProgressTracker.class);
+
+    @Override
+    public HashMap<String, String> call() throws Exception {
+        logger.debug("Copying chunk: "+chunk.getName());
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        List<Future<HashMap<String, String>>> futures = new ArrayList();
+        HashMap<String, String> archiveIds = new HashMap<>();
+        for (String archiveStoreId : archiveStores.keySet() ) {
+            ArchiveStore archiveStore = archiveStores.get(archiveStoreId);
+            DeviceTracker dt = new DeviceTracker();
+            dt.setArchiveStore(archiveStore);
+            dt.setArchiveStoreId(archiveStoreId);
+            dt.setChunkCount(chunkCount);
+            dt.setDepositId(depositId);
+            dt.setJobID(jobID);
+            dt.setEventStream(eventStream);
+            dt.setTarFile(chunk);
+            dt.setUserID(userID);
+            logger.debug("Creating device thread:" + archiveStore.getClass());
+            Future<HashMap<String, String>> dtFuture = executor.submit(dt);
+            futures.add(dtFuture);
+        }
+        executor.shutdown();
+
+        for (Future<HashMap<String, String>> future : futures) {
+            try {
+                HashMap<String, String> result = future.get();
+                archiveIds.putAll(result);
+            } catch (ExecutionException ee) {
+                Throwable cause = ee.getCause();
+                if (cause instanceof Exception) {
+                    logger.info("Device upload failed. " + cause.getMessage());
+                    throw (Exception) cause;
+                }
+            }
+        }
+        logger.debug("Chunk upload thread completed: " + this.chunkCount);
+        return archiveIds;
+    }
+
+    public File getChunk() {
+        return this.chunk;
+    }
+
+    public void setChunk(File chunk) {
+        this.chunk = chunk;
+    }
+
+    public int getChunkCount() {
+        return this.chunkCount;
+    }
+
+    public void setChunkCount(int chunkCount) {
+        this.chunkCount = chunkCount;
+    }
+
+    public HashMap<String, ArchiveStore> getArchiveStores() {
+        return this.archiveStores;
+    }
+
+    public void setArchiveStores(HashMap<String, ArchiveStore> archiveStores) {
+        this.archiveStores = archiveStores;
+    }
+
+    public String getDepositId() {
+        return this.depositId;
+    }
+
+    public void setDepositId(String depositId) {
+        this.depositId = depositId;
+    }
+
+    public String getJobID() {
+        return this.jobID;
+    }
+
+    public void setJobID(String jobID) {
+        this.jobID = jobID;
+    }
+
+    public EventSender getEventStream() {
+        return this.eventStream;
+    }
+
+    public void setEventStream(EventSender eventStream) {
+        this.eventStream = eventStream;
+    }
+
+    public File getTarFile() {
+        return this.tarFile;
+    }
+
+    public void setTarFile(File tarFile) {
+        this.tarFile = tarFile;
+    }
+
+    public String getUserID() {
+        return userID;
+    }
+
+    public void setUserID(String userID) {
+        this.userID = userID;
+    }
+}

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/ChunkUploadTracker.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/ChunkUploadTracker.java
@@ -21,7 +21,7 @@ public class ChunkUploadTracker implements Callable {
     private EventSender eventStream;
     private File tarFile;
     private String userID;
-    private static final Logger logger = LoggerFactory.getLogger(ProgressTracker.class);
+    private static final Logger logger = LoggerFactory.getLogger(ChunkUploadTracker.class);
 
     @Override
     public HashMap<String, String> call() throws Exception {

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/CopyBackFromArchive.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/CopyBackFromArchive.java
@@ -1,0 +1,30 @@
+package org.datavaultplatform.worker.operations;
+
+import org.datavaultplatform.common.io.Progress;
+import org.datavaultplatform.common.storage.ArchiveStore;
+import org.datavaultplatform.common.storage.Device;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+public class CopyBackFromArchive {
+    private static final Logger logger = LoggerFactory.getLogger(CopyBackFromArchive.class);
+
+    public static void copyBackFromArchive(ArchiveStore archiveStore, String archiveId, File tarFile) throws Exception {
+
+        CopyBackFromArchive.copyBackFromArchive(archiveStore, archiveId, tarFile, null);
+    }
+
+    public static void copyBackFromArchive(ArchiveStore archiveStore, String archiveId, File tarFile, String location) throws Exception {
+
+        // Ask the driver to copy files to the temp directory
+        Progress progress = new Progress();
+        if (location == null) {
+            ((Device)archiveStore).retrieve(archiveId, tarFile, progress);
+        } else {
+            ((Device)archiveStore).retrieve(archiveId, tarFile, progress, location);
+        }
+        logger.info("Copied: " + progress.dirCount + " directories, " + progress.fileCount + " files, " + progress.byteCount + " bytes");
+    }
+}

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/DeviceTracker.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/DeviceTracker.java
@@ -23,7 +23,7 @@ public class DeviceTracker implements Callable {
     private String archiveStoreId;
     private ArchiveStore archiveStore;
     private String userID;
-    private static final Logger logger = LoggerFactory.getLogger(ProgressTracker.class);
+    private static final Logger logger = LoggerFactory.getLogger(DeviceTracker.class);
 
     @Override
     public HashMap<String, String> call() throws Exception {

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/DeviceTracker.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/DeviceTracker.java
@@ -1,0 +1,139 @@
+package org.datavaultplatform.worker.operations;
+
+import org.datavaultplatform.common.event.deposit.CompleteCopyUpload;
+import org.datavaultplatform.common.event.deposit.StartCopyUpload;
+import org.datavaultplatform.common.io.Progress;
+import org.datavaultplatform.common.storage.ArchiveStore;
+import org.datavaultplatform.common.storage.Device;
+import org.datavaultplatform.worker.queue.EventSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.concurrent.Callable;
+
+public class DeviceTracker implements Callable {
+
+    private String jobID;
+    private String depositId;
+    private File tarFile;
+    private EventSender eventStream;
+    private int chunkCount = 0;
+    private String archiveStoreId;
+    private ArchiveStore archiveStore;
+    private String userID;
+    private static final Logger logger = LoggerFactory.getLogger(ProgressTracker.class);
+
+    @Override
+    public HashMap<String, String> call() throws Exception {
+        HashMap<String, String> archiveIds = new HashMap<>();
+        // Progress tracking (threaded)
+        Progress progress = new Progress();
+        ProgressTracker tracker = new ProgressTracker(progress, this.jobID, this.depositId, this.tarFile.length(), this.eventStream);
+        Thread trackerThread = new Thread(tracker);
+        trackerThread.start();
+        String depId = this.depositId;
+        if (this.chunkCount > 0) {
+            depId = depId + "." + this.chunkCount;
+        }
+        String archiveId;
+        // kick off new thread for each device ( we may already have kicked off x threads for chunks)
+        try {
+            this.eventStream.send(new StartCopyUpload(this.jobID, this.depositId, ((Device) this.archiveStore).name ).withUserId(this.userID));
+            if (((Device)this.archiveStore).hasDepositIdStorageKey()) {
+                archiveId = ((Device) this.archiveStore).store(depId, this.tarFile, progress);
+            } else {
+                archiveId = ((Device) this.archiveStore).store("/", this.tarFile, progress);
+            }
+            this.eventStream.send(new CompleteCopyUpload(this.jobID, this.depositId, ((Device) this.archiveStore).name ).withUserId(this.userID));
+        } finally {
+            // Stop the tracking thread
+            tracker.stop();
+            trackerThread.join();
+        }
+
+        logger.info("Copied: " + progress.dirCount + " directories, " + progress.fileCount + " files, " + progress.byteCount + " bytes");
+        // wait for all 3 to finish
+
+        if (this.chunkCount > 0 && archiveIds.get(this.archiveStoreId) == null) {
+            logger.info("ArchiveId is: " + archiveId);
+            String separator = FileSplitter.CHUNK_SEPARATOR;
+            logger.info("Separator is: " + separator);
+            int beginIndex = archiveId.lastIndexOf(separator);
+            logger.info("BeginIndex is: " + beginIndex);
+            archiveId = archiveId.substring(0, beginIndex);
+            logger.debug("Add to archiveIds: key: "+this.archiveStoreId+" ,value:"+archiveId);
+            archiveIds.put(archiveStoreId, archiveId);
+            logger.debug("archiveIds: "+archiveIds);
+        } else if(this.chunkCount == 0) {
+            archiveIds.put(archiveStoreId, archiveId);
+        }
+        logger.debug("Device thread completed: " + archiveId);
+        return archiveIds;
+    }
+
+    public String getJobID() {
+        return this.jobID;
+    }
+
+    public void setJobID(String jobID) {
+        this.jobID = jobID;
+    }
+
+    public String getDepositId() {
+        return this.depositId;
+    }
+
+    public void setDepositId(String depositId) {
+        this.depositId = depositId;
+    }
+
+    public File getTarFile() {
+        return this.tarFile;
+    }
+
+    public void setTarFile(File tarFile) {
+        this.tarFile = tarFile;
+    }
+
+    public EventSender getEventStream() {
+        return this.eventStream;
+    }
+
+    public void setEventStream(EventSender eventStream) {
+        this.eventStream = eventStream;
+    }
+
+    public int getChunkCount() {
+        return this.chunkCount;
+    }
+
+    public void setChunkCount(int chunkCount) {
+        this.chunkCount = chunkCount;
+    }
+
+    public String getArchiveStoreId() {
+        return this.archiveStoreId;
+    }
+
+    public void setArchiveStoreId(String archiveStoreId) {
+        this.archiveStoreId = archiveStoreId;
+    }
+
+    public ArchiveStore getArchiveStore() {
+        return this.archiveStore;
+    }
+
+    public void setArchiveStore(ArchiveStore archiveStore) {
+        this.archiveStore = archiveStore;
+    }
+
+    public String getUserID() {
+        return this.userID;
+    }
+
+    public void setUserID(String userID) {
+        this.userID = userID;
+    }
+}

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/queue/Receiver.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/queue/Receiver.java
@@ -42,6 +42,7 @@ public class Receiver {
     private String vaultSslPEMPath;
     AESMode encryptionMode = AESMode.GCM;
     private Boolean multipleValidationEnabled;
+    private int noChunkThreads;
 
     /**
      * Set the queue server
@@ -192,6 +193,12 @@ public class Receiver {
         this.multipleValidationEnabled = multipleValidationEnabled;
     }
 
+    public int getNoChunkThreads() { return this.noChunkThreads; }
+
+    public void setNoChunkThreads(int noChunkThreads) {
+        this.noChunkThreads = noChunkThreads;
+    }
+
     /**
      * Setup a connection to the queue then wait for messages to arrive.  When we recieve a message delivery
      * work out the type of task, check if it is a redelivery then complete the task.
@@ -219,7 +226,7 @@ public class Receiver {
         // Allow for priority messages so that a shutdown message can be prioritised if required.
         Map<String, Object> args = new HashMap<String, Object>();
         args.put("x-max-priority", 2);
-
+        
         channel.queueDeclare(queueName, true, false, false, args);
         logger.info("Waiting for messages");
         
@@ -268,7 +275,8 @@ public class Receiver {
                         chunkingEnabled, chunkingByteSize,
                         encryptionEnabled, encryptionMode, 
                         vaultAddress, vaultToken, 
-                        vaultKeyPath, vaultKeyName, vaultSslPEMPath, this.multipleValidationEnabled);
+                        vaultKeyPath, vaultKeyName, vaultSslPEMPath,
+                        this.multipleValidationEnabled, this.noChunkThreads);
                 concreteTask.performAction(context);
                 
             } catch (Exception e) {

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Deposit.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Deposit.java
@@ -426,7 +426,12 @@ public class Deposit extends Task {
             String archiveId, String location, boolean multipleCopies, HashMap<Integer, byte[]> ivs, 
             String encTarHash, String[] encChunksHash, boolean doVerification) throws Exception {
 
-        ExecutorService executor = Executors.newFixedThreadPool(25);
+        int noOfThreads = context.getNoChunkThreads();
+        if (noOfThreads != 0 && noOfThreads < 0 ) {
+            noOfThreads = 25;
+        }
+        logger.debug("Number of threads: " + noOfThreads);
+        ExecutorService executor = Executors.newFixedThreadPool(noOfThreads);
         List<Future<HashMap<String, String>>> futures = new ArrayList();
         for (int i = 0; i < chunkFiles.length; i++) {
             // if less that max threads started start new one
@@ -773,7 +778,12 @@ public class Deposit extends Task {
 	private void uploadToStorage(Context context, File tarFile) throws Exception {
 
 		if ( context.isChunkingEnabled() ) {
-            ExecutorService executor = Executors.newFixedThreadPool(25);
+            int noOfThreads = context.getNoChunkThreads();
+            if (noOfThreads != 0 && noOfThreads < 0 ) {
+                noOfThreads = 25;
+            }
+            logger.debug("Number of threads:" + noOfThreads);
+            ExecutorService executor = Executors.newFixedThreadPool(noOfThreads);
             List<Future<HashMap<String, String>>> futures = new ArrayList();
     		int chunkCount = 0;
     		// kick of 10 (maybe more) threads at a time?  each thread would kick off 3 threads of their own

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Deposit.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/tasks/Deposit.java
@@ -269,7 +269,7 @@ public class Deposit extends Task {
             		depId = depId + "." + chunkCount;
             }
             String archiveId;
-
+            // kick off new thread for each device ( we may already have kicked off x threads for chunks)
             try {
             	eventStream.send(new StartCopyUpload(jobID, depositId, ((Device) archiveStore).name ).withUserId(userID));
 	            if (((Device)archiveStore).hasDepositIdStorageKey()) {
@@ -283,6 +283,7 @@ public class Deposit extends Task {
                 tracker.stop();
                 trackerThread.join();
             }
+            // wait for all 3 to finish
 
             logger.info("Copied: " + progress.dirCount + " directories, " + progress.fileCount + " files, " + progress.byteCount + " bytes");
             
@@ -354,6 +355,7 @@ public class Deposit extends Task {
             String encTarHash, String[] encChunksHash, boolean doVerification) throws Exception {
         
         for (int i = 0; i < chunkFiles.length; i++) {
+            // if less that max threads started start new one
             File chunkFile = chunkFiles[i];
             String chunkHash = chunksHash[i];
             
@@ -816,7 +818,9 @@ public class Deposit extends Task {
 	private void uploadToStorage(Context context, File tarFile) throws Exception {
 		if ( context.isChunkingEnabled() ) {
     		int chunkCount = 0;
+    		// kick of 10 (maybe more) threads at a time?  each thread would kick off 3 threads of their own
     		for (File chunk : chunkFiles){
+                // kick of 10 (maybe more) threads at a time?  each thread would kick off 3 threads of their own
     			chunkCount++;
     			logger.debug("Copying chunk: "+chunk.getName());
     			this.copyToArchiveStorage(chunk, chunkCount);

--- a/datavault-worker/src/main/resources/config/datavault-worker.xml
+++ b/datavault-worker/src/main/resources/config/datavault-worker.xml
@@ -37,6 +37,7 @@
         <property name="EncryptionEnabled" value="${encryption.enabled:false}"/>
         <property name="EncryptionMode" value="${encryption.mode:GCM}"/>
         <property name="multipleValidationEnabled" value="${validate.multiple.enabled:true}"/>
+        <property name="noChunkThreads" value="${chunk.threads:20}" />
     </bean>
 
     <bean id="eventSender" class="org.datavaultplatform.worker.queue.EventSender">


### PR DESCRIPTION
I've added threads in a number of places along with a general tidy up.  You need a new datavault.properties value of something like chunk.threads = 25.

Now 
both TSM uploads are threaded
both Device uploads are threaded
x number of chunk uploads for a deposit are threaded
x number of chunk downloads for a deposit are threaded

I've done initial testing on my machine and a little TSM testing on demo (though a lot has changed since the).  Need to test on demo before merging / fixing