### PR TITLE
IssueID #Off ticket Revert buffer change in FileSplitter

### DIFF
--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/FileSplitter.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/operations/FileSplitter.java
@@ -19,8 +19,8 @@ public class FileSplitter {
     
     public static int DEFAULT_CHUNK_SIZE = 500 * 1000 * 1000; // 500MB
     
-    //public static int BUFFER_SIZE = 8 * 1024; // 8KB
-    public static int BUFFER_SIZE = 1024 * 1024; // 1MB
+    public static int BUFFER_SIZE = 8 * 1024; // 8KB
+    //public static int BUFFER_SIZE = 1024 * 1024; // 1MB
     
     public static String CHUNK_SEPARATOR = "."; // 8KB
     


### PR DESCRIPTION
1) Reverted the buffer size change.  I didn't think it was doing anything but I've seen a slowdown in certain areas of the current 10 TB test so removing just in case.