### PR TITLE
IssueID #RSS212-148  Added functionality so that once the PendingVault has been confirmed it cannot be changed (unless rejected by admin when it is curated)

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/PendingVaultsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/PendingVaultsService.java
@@ -346,6 +346,12 @@ public class PendingVaultsService {
             vault.setPureLink(pureLink);
         }
 
+        Boolean confirmed = createVault.getConfirmed();
+        logger.debug("Confirmed is: '" + confirmed + "'");
+        if (confirmed != null) {
+            vault.setConfirmed(confirmed);
+        }
+
         return vault;
     }
     

--- a/datavault-broker/src/main/resources/release-sql/5.0.0/pending-vaults.sql
+++ b/datavault-broker/src/main/resources/release-sql/5.0.0/pending-vaults.sql
@@ -33,4 +33,5 @@ ALTER TABLE Role_assignments ADD COLUMN pending_vault_id varchar(36) default nul
 ALTER TABLE Role_assignments ADD CONSTRAINT `FK_Pending_Vault_ID` FOREIGN KEY (`pending_vault_id`) REFERENCES `PendingVaults` (`id`);
 ALTER TABLE Role_assignments ADD UNIQUE KEY `UK_Pending_Vault_ID` (`role_id`,`user_id`,`pending_vault_id`);
 ALTER TABLE PendingVaults add column contact TEXT;
-ALTER TABLE PendingVaults add column pureLink bit not null default true;
+ALTER TABLE PendingVaults add column pureLink bit not null default false;
+ALTER TABLE PendingVaults add column confirmed bit not null default false;

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/PendingVault.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/PendingVault.java
@@ -131,6 +131,9 @@ public class PendingVault {
     @OneToMany(targetEntity=PendingDataCreator.class, mappedBy="pendingVault", fetch=FetchType.LAZY)
     private List<PendingDataCreator> dataCreators;
 
+    @Column(name = "confirmed", nullable = false)
+    private Boolean confirmed = false;
+
     @Column(name = "pureLink", nullable = false)
     private Boolean pureLink = false;
 
@@ -323,6 +326,16 @@ public class PendingVault {
         this.pureLink = pureLink;
     }
 
+    public Boolean getConfirmed() {
+        return this.confirmed;
+    }
+
+    public void setConfirmed(Boolean confirmed) {
+        this.confirmed = confirmed;
+    }
+
+
+
     public VaultInfo convertToResponse() {
         VaultInfo retVal = new VaultInfo();
         retVal.setID(this.id);
@@ -377,6 +390,7 @@ public class PendingVault {
         }
         retVal.setContact(this.contact);
         retVal.setPureLink(this.pureLink);
+        retVal.setConfirmed(this.confirmed);
 
         return retVal;
     }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/request/CreateVault.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/request/CreateVault.java
@@ -49,8 +49,8 @@ public class CreateVault {
     @ApiObjectField(description = "The date by which the vault should be reviewed for decision as to whether it should be deleted or whether there are funds available to support continued storage")
     private String reviewDate;
 
-    @ApiObjectField(description = "Is the data a mid completion save")
-    private Boolean partial = false;
+    @ApiObjectField(description = "Has the pending vault been confirmed")
+    private Boolean confirmed = false;
 
     @ApiObjectField(description = "Did the user accept the various rules on the create vault intro page")
     private Boolean affirmed = false;
@@ -200,12 +200,12 @@ public class CreateVault {
         this.reviewDate = reviewDate;
     }
 
-    public Boolean isPartial() {
-        return this.partial;
+    public Boolean getConfirmed() {
+        return this.confirmed;
     }
 
-    public void setPartial(Boolean partial) {
-        this.partial = partial;
+    public void setConfirmed(Boolean confirmed) {
+        this.confirmed = confirmed;
     }
 
     public Boolean getAffirmed() {

--- a/datavault-common/src/main/java/org/datavaultplatform/common/response/VaultInfo.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/response/VaultInfo.java
@@ -114,6 +114,9 @@ public class VaultInfo {
     @ApiObjectField(description = "Did the user accept the Pure Link rule on the summary page")
     private Boolean pureLink = false;
 
+    @ApiObjectField(description = "Did the user confirm the pending vault yet")
+    private Boolean confirmed = false;
+
     @ApiObjectField(description = "Pure Contact")
     private String contact;
 
@@ -491,5 +494,13 @@ public class VaultInfo {
 
     public void setPureLink(Boolean pureLink) {
         this.pureLink = pureLink;
+    }
+
+    public Boolean getConfirmed() {
+        return confirmed;
+    }
+
+    public void setConfirmed(Boolean confirmed) {
+        this.confirmed = confirmed;
     }
 }

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/VaultsController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/VaultsController.java
@@ -413,8 +413,8 @@ public class VaultsController {
         cv.setDepositors(vault.getDepositorIds());
         cv.setDataCreators(vault.getDataCreators());
         cv.setNotes(vault.getNotes());
-        cv.setPartial(true);
         cv.setPureLink(vault.getPureLink());
+        cv.setConfirmed(vault.getConfirmed());
 
         model.addAttribute("vault", cv);
         RetentionPolicy[] policies = restService.getRetentionPolicyListing();
@@ -486,7 +486,6 @@ public class VaultsController {
                 return result;
             }
 
-            vault.setPartial(true);
             if (vault.getPendingID() == null || vault.getPendingID().isEmpty()) {
                 newVault = restService.addPendingVault(vault);
             } else {
@@ -524,7 +523,7 @@ public class VaultsController {
             if (userResult != null && ! userResult.isEmpty()) {
                 return userResult;
             }
-            vault.setPartial(false);
+            vault.setConfirmed(true);
             if (vault.getPendingID() == null || vault.getPendingID().isEmpty()) {
                 newVault = restService.addPendingVault(vault);
             } else {
@@ -539,7 +538,6 @@ public class VaultsController {
         } else if ("Validate".equals(action)) {
             // this will be the code that moves from pending vault to validated vault
             // when an admin gives the ok
-            vault.setPartial(false);
 
             // add the new vault
             // remove all the pending stuff for the vault;

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/affirmationFieldset.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/affirmationFieldset.ftl
@@ -29,8 +29,10 @@
             </label>
         </div>
     </div>
+    <#if vault.confirmed?c=="false">
     <button type="submit" name="save" value="Save" class="save action-button-previous btn btn-default" >
         <span class="glyphicon glyphicon-floppy-disk" aria-hidden="true"></span> Save
     </button>
+    </#if>
     <button type="button" name="next" class="next action-button btn btn-primary" disabled>Next Step &raquo;</button>
 </fieldset>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/billingFieldset.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/billingFieldset.ftl
@@ -82,8 +82,10 @@
         Select one of the billing option above.
     </div>
     <button type="button" name="previous" class="previous action-button-previous btn btn-default" >&laquo; Previous</button>
+    <#if vault.confirmed?c=="false">
     <button type="submit" name="save" value ="Save" class="save action-button-previous btn btn-default" >
         <span class="glyphicon glyphicon-floppy-disk" aria-hidden="true"></span> Save
     </button>
+    </#if>
     <button type="button" name="next" class="next action-button btn btn-primary" disabled>Next Step &raquo;</button>
 </fieldset>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/infoFieldset.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/infoFieldset.ftl
@@ -143,8 +143,10 @@
     </div>
 
     <button type="button" name="previous" class="previous action-button-previous btn btn-default" >&laquo; Previous</button>
+    <#if vault.confirmed?c=="false">
     <button type="submit" name="save" value="Save" class="save action-button-previous btn btn-default" >
         <span class="glyphicon glyphicon-floppy-disk" aria-hidden="true"></span> Save
     </button>
+    </#if>
     <button type="button" name="next" class="next action-button btn btn-primary">Next Step &raquo;</button>
 </fieldset>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/summaryFieldset.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/summaryFieldset.ftl
@@ -64,6 +64,11 @@
                     <th scope="col">Depositors</th>
                     <td>${vault.getDepositorsAsString()}</td>
                 </tr>
+                <tr>
+                    <th scope="col">Confirmed</th>
+                    <td><@spring.bind "vault.confirmed" />
+                        ${spring.status.value!""}</td>
+                </tr>
                 </tbody>
             </table>
         </div>
@@ -84,10 +89,12 @@
         </div>
     </div>
     <button type="button" name="previous" class="previous action-button-previous btn btn-default" >&laquo; Previous</button>
+    <#if vault.confirmed?c=="false">
     <button type="submit" name="save" value="Save" class="save action-button-previous btn btn-default" >
         <span class="glyphicon glyphicon-floppy-disk" aria-hidden="true"></span> Save
     </button>
     <button type="submit" name="confirm" value="Confirm" class="action-button btn btn-success">
         <span class="glyphicon glyphicon-ok" aria-hidden="true"></span> Confirm
     </button>
+    </#if>
 </fieldset>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/usersFieldset.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/usersFieldset.ftl
@@ -89,9 +89,11 @@
         </div>
     </div>
     <button type="button" name="previous" class="previous action-button-previous btn btn-default" >&laquo; Previous</button>
+    <#if vault.confirmed?c=="false">
     <button type="submit" name="save" value="Save" class="save action-button-previous btn btn-default" >
         <span class="glyphicon glyphicon-floppy-disk" aria-hidden="true"></span> Save
     </button>
+    </#if>
     <button type="button" name="next" class="next action-button btn btn-primary">Next Step &raquo;</button>
     <script>
         $(".autocomplete").autocomplete({


### PR DESCRIPTION


Added a confirmed value to the PendingVault class which is used to suppress the save / confirm buttons in the gui.  The workflow will be it will then be reviewed and either accepted where it is moved to a full vault or sent back for changes which will reset the confirmed value.

This commit requires sql updates to be run

1) Updated PendingVault to have new confirmed member and accessors
2) Updated CreateVault to have new confirmed member and accessors also removed partial member
3) Updated VaultInfo to have new confirmed member and accessors
4) Updated webapp/controllers/VaultsController so that the new member is set / got where required so it is persisted and retrieved when relevant
5) Updated all the metadata gui fieldsets so that the save and confirm button are hidden / displayed as relevant