### PR TITLE
IssueID #RSS212-148  Added front end validation so the info fieldset next button is disabled till all mandatory fields completed

### DIFF
--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/infoFieldset.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/infoFieldset.ftl
@@ -148,5 +148,5 @@
         <span class="glyphicon glyphicon-floppy-disk" aria-hidden="true"></span> Save
     </button>
     </#if>
-    <button type="button" name="next" class="next action-button btn btn-primary">Next Step &raquo;</button>
+    <button type="button" name="next" class="next action-button btn btn-primary" disabled>Next Step &raquo;</button>
 </fieldset>

--- a/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
+++ b/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
@@ -20,6 +20,26 @@ $(document).ready(function(){
         $(this).parents("fieldset").children(".next").prop( "disabled", !$(this).is(":checked") );
     }).trigger('change');  ;
 
+    $("#vaultName, #description, #policyID, #groupID, #reviewDate").change(function(){
+        // if all the mandatory values in the info field set are non null or empty set the next button
+        // display value to true
+        // name
+        var nameResult = ($( "input[type=text][id=vaultName]").val().trim() === '');
+        // description
+        var descResult = ($( "textarea[type=text][id=description]").val() === '');
+        // retention policy
+        var rpResult = ($("#policyID option:selected").val() === '' || $("#policyID option:selected").prop("disabled"));
+        // school
+        var schoolResult = ($("#groupID option:selected").val() === '' || $("#groupID option:selected").prop("disabled"));
+        // review date
+        var reviewResult = ($( "input[id=reviewDate]").val().trim() === '');
+        if (nameResult === false && descResult === false && rpResult === false && schoolResult === false  && reviewResult === false) {
+            $(this).parents("fieldset").children(".next").prop("disabled", false);
+        } else {
+            $(this).parents("fieldset").children(".next").prop("disabled", true);
+        }
+    }).trigger('change');  ;
+
     $("#billing-choice-na").change(function(){
         $('.collapse').collapse('hide');
         $(this).parents("fieldset").children(".next").prop( "disabled", false );


### PR DESCRIPTION

1) Updated InfoFieldset.ftl so that the next button is disabled by default
2) Updated new-create-prototype.js so that it contains code to enable the button when all the mandatory fields have non empty values