### PR TITLE
IssueID #RSS212-128  Added delete pending vault functionality

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/admin/AdminPendingVaultsController.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/admin/AdminPendingVaultsController.java
@@ -31,11 +31,18 @@ public class AdminPendingVaultsController {
 	public void setPendingVaultsService(PendingVaultsService pendingVaultsService) {
         this.pendingVaultsService = pendingVaultsService;
     }
-	
+	/*
 	@RequestMapping(value = "/admin/pendingVaults/addVault/{pendingVaultId}", method = RequestMethod.POST)
 	public boolean addVaultForPendingVault(@PathVariable("pendingVaultId") String pendingVaultId,
 			                               @RequestBody Date reviewDate) throws Exception {
 		return false;
+	}*/
+
+	@RequestMapping(value = "/admin/pendingVaults/{id}", method = RequestMethod.DELETE)
+	public void delete(@RequestHeader(value = "X-UserID", required = true) String userID,
+									  @PathVariable("id") String vaultID) throws Exception {
+
+		pendingVaultsService.delete(vaultID);
 	}
 
 

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/PendingVaultsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/PendingVaultsService.java
@@ -58,6 +58,21 @@ public class PendingVaultsService {
 
     }
 
+    public void delete(String id) {
+        logger.info("Called delete for '" + id + "'");
+        // delete role_assigmnets for id
+        //for each role
+        List<RoleAssignment> roles = permissionsService.getRoleAssignmentsForPendingVault(id);
+        for (RoleAssignment role : roles) {
+            permissionsService.deleteRoleAssignment(role.getId());
+        }
+        // delete pending data creators
+        // deleted by cascade in PendingVaults hibernate config
+        //for each creator
+        //pendingDataCreatorsService.deletePendingDataCreator(creatorID);
+        // delete pending vault
+        pendingVaultDAO.deleteById(id);
+    }
     public PendingVault getPendingVault(String vaultID) {
         return pendingVaultDAO.findById(vaultID);
     }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/PendingVault.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/PendingVault.java
@@ -128,7 +128,7 @@ public class PendingVault {
     private List<User> nominatedDataManagers;
 
     @JsonIgnore
-    @OneToMany(targetEntity=PendingDataCreator.class, mappedBy="pendingVault", fetch=FetchType.LAZY)
+    @OneToMany(targetEntity=PendingDataCreator.class, mappedBy="pendingVault", orphanRemoval = true, cascade = CascadeType.PERSIST, fetch=FetchType.LAZY)
     private List<PendingDataCreator> dataCreators;
 
     @Column(name = "confirmed", nullable = false)

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/PendingVaultDAO.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/PendingVaultDAO.java
@@ -23,4 +23,6 @@ public interface PendingVaultDAO {
     public int getTotalNumberOfPendingVaults(String userId);
 
 	public int getTotalNumberOfPendingVaults(String userId, String query);
+
+    public void deleteById(String Id);
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/PendingVaultDAOImpl.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/PendingVaultDAOImpl.java
@@ -204,4 +204,21 @@ public class PendingVaultDAOImpl implements PendingVaultDAO {
             }
         }
     }
+
+    @Override
+    public void deleteById(String Id) {
+
+        Session session = this.sessionFactory.openSession();
+        Criteria criteria = session.createCriteria(PendingVault.class);
+        criteria.add(Restrictions.eq("id", Id));
+        PendingVault pv = (PendingVault) criteria.uniqueResult();
+        //session.delete(pv);
+        //session.flush();
+        //session.close();
+
+        Transaction tx = session.beginTransaction();
+        session.delete(pv);
+        tx.commit();
+        session.close();
+    }
 }

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminPendingVaultsController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminPendingVaultsController.java
@@ -122,24 +122,7 @@ public class AdminPendingVaultsController {
 
         return "admin/pendingVaults/summary";
     }
-/*
-    // Upgrade a pending vault to a full vault
-    @RequestMapping(value = "/admin/pendingVaults/upgrade/{pendingVaultId}/", method = RequestMethod.POST)
-    public String upgradeVault(ModelMap model, @PathVariable("pendingVaultId") String vaultID, Principal principal) {
 
-        // need to either pass in create vault or get vaultnfo from the pending id param
-        // and convert it to create vault object like in VaultController.getPendingVault
-        VaultInfo pendingVault = restService.getPendingVault(vaultID);
-        CreateVault cv = pendingVault.convertToCreate();
-        logger.info("Attempting to upgrade pending vault to pull vault");
-        VaultInfo newVault = restService.addVault(cv);
-        logger.info("Completed upgrading pending vault to pull vault");
-        //need to add full vault datacreators, roles etc.
-        // any other new info too pure stuff billing etc.
-        String vaultUrl = "/vaults/" + newVault.getID() + "/";
-        return "redirect:" + vaultUrl;
-    }
-*/
     @RequestMapping(value = "/admin/pendingVaults/upgrade/{pendingVaultId}", method = RequestMethod.GET)
     public String upgradeVault(@PathVariable("pendingVaultId") String pendingVaultID) {
         // need to either pass in create vault or get vaultnfo from the pending id param
@@ -180,17 +163,25 @@ public class AdminPendingVaultsController {
         return "redirect:/admin/pendingVaults";
     }
 
+*/
 
-    
+    /*
     @RequestMapping(value = "/admin/pendingVaults/delete/{pendingVaultId}", method = RequestMethod.GET)
     public String deletePendingVault(@PathVariable("pendingVaultId") String pendingVaultID) {
     	logger.info("pendingVaultID: " + pendingVaultID);
-//        PendingVault pendingVault = restService.getPendingVaultRecord(vaultID);
-//        model.addAttribute("pendingVault", pendingVault);
+        PendingVault pendingVault = restService.getPendingVaultRecord(vaultID);
+        model.addAttribute("pendingVault", pendingVault);
 
         return "redirect:/admin/pendingVaults";
+    }*/
+
+    @RequestMapping(value = "/admin/pendingVaults/{pendingVaultID}", method = RequestMethod.GET)
+    public String deletePendingVault(ModelMap model, @PathVariable("pendingVaultID") String pendingVaultID) throws Exception {
+
+        restService.deletePendingVault(pendingVaultID);
+        return "redirect:/admin/pendingVaults";
     }
-*/
+
     private String constructTableRecordsInfo(int offset, int recordsTotal, int filteredRecords, int numberOfRecordsonPage, boolean isFiltered) {
 		StringBuilder recordsInfo = new StringBuilder();
 		recordsInfo.append("Showing ").append(offset + 1).append(" - ").append(offset + numberOfRecordsonPage);

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/RestService.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/RestService.java
@@ -676,6 +676,10 @@ public class RestService {
         delete(brokerURL + "/admin/deposits/" + depositId, String.class);
     }
 
+    public void deletePendingVault(String pendingVaultId) {
+        delete(brokerURL + "/admin/pendingVaults/" + pendingVaultId, Void.class);
+    }
+
     public BillingInformation updateBillingInfo(String vaultId,BillingInformation billingInfo) {
         HttpEntity<?> response = post(brokerURL + "/admin/billing/" + vaultId+ "/updateBilling" , BillingInformation.class,billingInfo);
         return (BillingInformation)response.getBody();

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/pendingVaults/summary.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/pendingVaults/summary.ftl
@@ -169,12 +169,9 @@
      <#if (pendingVault.ID)??>
           <a name="delete-pending-vault" class="btn btn-default" 
           href="${springMacroRequestContext.getContextPath()}/admin/pendingVaults"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span>Cancel</a>
-       
 
           <a name="delete-pending-vault" class="btn btn-danger" 
-          href="${springMacroRequestContext.getContextPath()}/admin/pendingVaults/delete/${pendingVault.getID()}"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span> Delete Pending Vault</a>
-
-         
+          href="${springMacroRequestContext.getContextPath()}/admin/pendingVaults/${pendingVault.getID()}"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span> Delete Pending Vault</a>
          <button type="submit" value="submit" class="btn btn-success">
               <span class="glyphicon glyphicon-folder-close"></span>
                                     Create Vault


### PR DESCRIPTION
The delete pendiing vault button on the admin/pv/summary page now deletes the relevant PV, PDDatacreators and role_assignments

1) Updated the webapp/AdminPendingVaultsController to have a new delete method
2) Updated the broker/AdminPendingVaultsController to have a new delete method
3) Added delete methods to the various PendingVaultDAO / Impl / Service classes
4) Updated the admin/pv/summary.ftl to use the new delete method.

At the point the admin delete does delete everything as expected but we need to test that only admins can do this (same as we need to test only admins can upgrade a pv to the full vault)