### PR TITLE
IssueID #RSS212-128 Added functionality so that pending data creators are added to full vault when upgraded

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/VaultsController.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/VaultsController.java
@@ -7,6 +7,7 @@ import org.datavaultplatform.common.event.roles.CreateRoleAssignment;
 import org.datavaultplatform.common.event.roles.OrphanVault;
 import org.datavaultplatform.common.event.roles.TransferVaultOwnership;
 import org.datavaultplatform.common.event.vault.Create;
+import org.datavaultplatform.common.event.vault.Pending;
 import org.datavaultplatform.common.event.vault.UpdatedDescription;
 import org.datavaultplatform.common.event.vault.UpdatedName;
 import org.datavaultplatform.common.model.*;
@@ -470,14 +471,6 @@ public class VaultsController {
 
         pendingVaultsService.addCreator(createVault, userID, vault.getId());
 
-        //Create vaultEvent = new Create(vault.getId());
-        //vaultEvent.setVault(vault);
-        //vaultEvent.setUser(usersService.getUser(userID));
-        //vaultEvent.setAgentType(Agent.AgentType.BROKER);
-        //vaultEvent.setAgent(clientsService.getClientByApiKey(clientKey).getName());
-
-        //eventService.addEvent(vaultEvent);
-
         // Check the retention policy of the newly created vault
         //try {
         //    vaultsService.checkRetentionPolicy(vault.getId());
@@ -551,12 +544,27 @@ public class VaultsController {
 
         vaultsService.addVault(vault);
 
-        RoleAssignment dataOwnerRoleAssignment = new RoleAssignment();
-        dataOwnerRoleAssignment.setUserId(userID);
-        dataOwnerRoleAssignment.setVaultId(vault.getID());
-        dataOwnerRoleAssignment.setRole(permissionsService.getDataOwner());
-        permissionsService.createRoleAssignment(dataOwnerRoleAssignment);
+        //RoleAssignment dataOwnerRoleAssignment = new RoleAssignment();
+        //dataOwnerRoleAssignment.setUserId(userID);
+        //dataOwnerRoleAssignment.setVaultId(vault.getID());
+        //dataOwnerRoleAssignment.setRole(permissionsService.getDataOwner());
+        //permissionsService.createRoleAssignment(dataOwnerRoleAssignment);
 
+        vaultsService.addDepositorRoles(createVault, vault.getID());
+        vaultsService.addOwnerRole(createVault, vault.getID(), userID);
+        vault = vaultsService.processDataCreatorParams(createVault, vault);
+        vaultsService.addNDMRoles(createVault, vault.getID());
+        //pendingVaultsService.addCreator(createVault, userID, vault.getId());
+
+        // TODO: Add new Pending Vault created event that includes the creators name as that will be lost when the vault is upgraded
+        //Pending pendingEvent = new Pending(createVault.getPendingID());
+        //pendingEvent.setVault(vault);
+        //permissionsService.get
+        //pendingEvent.setUser(usersService.getUser(createVault.get);
+        //pendingEvent.setAgentType(Agent.AgentType.BROKER);
+        //pendingEvent.setAgent(clientsService.getClientByApiKey(clientKey).getName());
+
+        //eventService.addEvent(pendingEvent);
         Create vaultEvent = new Create(vault.getID());
         vaultEvent.setVault(vault);
         vaultEvent.setUser(usersService.getUser(userID));

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/DataCreatorsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/DataCreatorsService.java
@@ -1,0 +1,32 @@
+package org.datavaultplatform.broker.services;
+
+import org.datavaultplatform.common.model.DataCreator;
+import org.datavaultplatform.common.model.dao.DataCreatorDAO;
+import org.datavaultplatform.common.model.dao.PendingDataCreatorDAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class DataCreatorsService {
+    private DataCreatorDAO dataCreatorDAO;
+    private final Logger logger = LoggerFactory.getLogger(DataCreatorsService.class);
+
+    public void setDataCreatorDAO(DataCreatorDAO dataCreatorDAO) {
+        this.dataCreatorDAO = dataCreatorDAO;
+    }
+
+    public void addCreators(List<DataCreator> creators) {
+
+        if (creators != null  && ! creators.isEmpty()) {
+            this.dataCreatorDAO.save(creators);
+        }
+    }
+
+    public void deletePendingDataCreator(String creatorId) {
+        if (dataCreatorDAO.findById(creatorId) == null) {
+            throw new IllegalStateException("Cannot delete a role assignment that does not exist");
+        }
+        this.dataCreatorDAO.delete(creatorId);
+    }
+}

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/PendingDataCreatorsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/PendingDataCreatorsService.java
@@ -1,7 +1,6 @@
 package org.datavaultplatform.broker.services;
 
 import org.datavaultplatform.common.model.PendingDataCreator;
-import org.datavaultplatform.common.model.RoleAssignment;
 import org.datavaultplatform.common.model.dao.PendingDataCreatorDAO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/VaultsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/VaultsService.java
@@ -18,6 +18,8 @@ public class VaultsService {
 
     private RetentionPoliciesService retentionPoliciesService;
 
+    private DataCreatorsService dataCreatorsService;
+
     public void setRolesAndPermissionsService(RolesAndPermissionsService rolesAndPermissionsService) {
         this.rolesAndPermissionsService = rolesAndPermissionsService;
     }
@@ -29,6 +31,8 @@ public class VaultsService {
     public void setRetentionPoliciesService(RetentionPoliciesService retentionPoliciesService) {
         this.retentionPoliciesService = retentionPoliciesService;
     }
+
+    public void setDataCreatorsService(DataCreatorsService dataCreatorsService) { this.dataCreatorsService = dataCreatorsService; }
 
     public List<Vault> getVaults() {
         return vaultDAO.list();
@@ -195,26 +199,26 @@ public class VaultsService {
 
     public Vault processDataCreatorParams(CreateVault createVault, Vault vault) {
         List<String> dcs = createVault.getDataCreators();
-//        if (dcs != null) {
-//            logger.debug("Data creator list is :'" + dcs + "'");
-//            List<PendingDataCreator> creators = new ArrayList();
-//            for (String creator : dcs) {
-//                if (creator != null && !creator.isEmpty()) {
-//                    DataCreator dc = new DataCreator();
-//                    dc.setName(creator);
-//                    dc.setVault(vault);
-//                    creators.add(dc);
-//                }
-//            }
-//            vault.setDataCreator(creators);
-//        } else {
-//            logger.debug("Data creator list is :null");
-//        }
-//
-//        List<PendingDataCreator> creators = vault.getDataCreators();
-//        if (creators != null && ! creators.isEmpty()) {
-//            dataCreatorsService.addPendingCreators(creators);
-//        }
+        if (dcs != null) {
+            logger.debug("Data creator list is :'" + dcs + "'");
+            List<DataCreator> creators = new ArrayList();
+            for (String creator : dcs) {
+                if (creator != null && !creator.isEmpty()) {
+                    DataCreator dc = new DataCreator();
+                    dc.setName(creator);
+                    dc.setVault(vault);
+                    creators.add(dc);
+                }
+            }
+            vault.setDataCreator(creators);
+        } else {
+            logger.debug("Data creator list is :null");
+        }
+
+        List<DataCreator> creators = vault.getDataCreators();
+        if (creators != null && ! creators.isEmpty()) {
+            dataCreatorsService.addCreators(creators);
+        }
 
         return vault;
     }

--- a/datavault-broker/src/main/resources/release-sql/5.0.0/pending-vaults.sql
+++ b/datavault-broker/src/main/resources/release-sql/5.0.0/pending-vaults.sql
@@ -36,3 +36,11 @@ ALTER TABLE PendingVaults add column contact TEXT;
 ALTER TABLE PendingVaults add column pureLink bit not null default false;
 ALTER TABLE PendingVaults add column confirmed bit not null default false;
 ALTER TABLE Vaults MODIFY snapshot longtext NULL DEFAULT null;
+
+CREATE TABLE `DataCreators` (
+                                       `id` varchar(36) NOT NULL,
+                                       `name` text NOT NULL,
+                                       `version` bigint(20) NOT NULL,
+                                       `vault_id` varchar(36) DEFAULT NULL,
+                                       PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-root.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-root.xml
@@ -41,6 +41,7 @@
         <property name="vaultDAO" ref="vaultDAO" />
         <property name="rolesAndPermissionsService" ref="rolesAndPermissionsService" />
         <property name="retentionPoliciesService" ref="retentionPoliciesService" />
+        <property name="dataCreatorsService" ref="dataCreatorsService" />
     </bean>
 
     <bean id="pendingVaultsService" class="org.datavaultplatform.broker.services.PendingVaultsService">
@@ -54,6 +55,10 @@
 
     <bean id="pendingDataCreatorsService" class="org.datavaultplatform.broker.services.PendingDataCreatorsService">
         <property name="pendingDataCreatorDAO" ref="pendingDataCreatorDAO" />
+    </bean>
+
+    <bean id="dataCreatorsService" class="org.datavaultplatform.broker.services.DataCreatorsService">
+        <property name="dataCreatorDAO" ref="dataCreatorDAO" />
     </bean>
 
     <bean id="vaultsReviewService" class="org.datavaultplatform.broker.services.VaultsReviewService">
@@ -384,6 +389,10 @@
     </bean>
 
     <bean id="pendingDataCreatorDAO" class="org.datavaultplatform.common.model.dao.PendingDataCreatorDAOImpl">
+        <property name="sessionFactory" ref="sessionFactory" />
+    </bean>
+
+    <bean id="dataCreatorDAO" class="org.datavaultplatform.common.model.dao.DataCreatorDAOImpl">
         <property name="sessionFactory" ref="sessionFactory" />
     </bean>
 

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/vault/Pending.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/vault/Pending.java
@@ -1,0 +1,16 @@
+package org.datavaultplatform.common.event.vault;
+
+import org.datavaultplatform.common.event.Event;
+
+import javax.persistence.Entity;
+
+@Entity
+public class Pending extends Event {
+
+    public Pending() {};
+    public Pending(String vaultId) {
+        super("Created pending vault");
+        this.eventClass = Pending.class.getCanonicalName();
+        this.vaultId = vaultId;
+    }
+}

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/DataCreator.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/DataCreator.java
@@ -1,0 +1,70 @@
+package org.datavaultplatform.common.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.datavaultplatform.common.response.VaultInfo;
+import org.hibernate.annotations.GenericGenerator;
+import org.jsondoc.core.annotation.ApiObject;
+
+import javax.persistence.*;
+import java.util.Date;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@ApiObject(name = "DataCreator")
+@Entity
+@Table(name="DataCreators")
+public class DataCreator {
+    private static final long ZERO = 0l;
+
+    // PDC Identifier
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid2")
+    @Column(name = "id", unique = true, length = 36)
+    private String id;
+
+    // Hibernate version
+    @Version
+    private long version;
+
+    // Name of the creator
+    @Column(name = "name", nullable = false, columnDefinition = "TEXT", length=400)
+    private String name;
+
+    // A creator is related to a number of vaults
+    @JsonIgnore
+    @ManyToOne
+    private Vault vault;
+
+    public String getId() {
+        return this.id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public long getVersion() {
+        return this.version;
+    }
+
+    public void setVersion(long version) {
+        this.version = version;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() { return name; }
+
+    public void setVault(Vault Vault) {
+        this.vault = vault;
+    }
+
+    public Vault getVault() {
+        return this.vault;
+    }
+}

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/Vault.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/Vault.java
@@ -137,6 +137,10 @@ public class Vault {
     @Lob
     @Column(name = "snapshot", nullable = false)
     private String snapshot;
+
+    @JsonIgnore
+    @OneToMany(targetEntity=DataCreator.class, mappedBy="vault", fetch=FetchType.LAZY)
+    private List<DataCreator> dataCreators;
     
     public Vault() {}
     public Vault(String name) {
@@ -290,9 +294,19 @@ public class Vault {
 		return billinginfo;
 		
 	}
+
 	public void setBillinginfo(BillingInfo billinginfo) {
 		this.billinginfo = billinginfo;
 	}
+
+    public List<DataCreator> getDataCreators() {
+        return this.dataCreators;
+    }
+
+    public void setDataCreator(List<DataCreator> dataCreators) {
+        this.dataCreators = dataCreators;
+    }
+
 	public VaultInfo convertToResponse() {
         return new VaultInfo(
                 id,

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/DataCreatorDAO.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/DataCreatorDAO.java
@@ -1,0 +1,15 @@
+package org.datavaultplatform.common.model.dao;
+
+import org.datavaultplatform.common.model.DataCreator;
+
+import java.util.List;
+
+public interface DataCreatorDAO {
+    void save(List<DataCreator> dataCreators);
+
+    DataCreator findById(String Id);
+
+    void update(DataCreator dataCreator);
+
+    void delete(String id);
+}

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/DataCreatorDAOImpl.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/DataCreatorDAOImpl.java
@@ -1,8 +1,6 @@
 package org.datavaultplatform.common.model.dao;
 
-import org.datavaultplatform.common.model.PendingDataCreator;
-import org.datavaultplatform.common.model.PendingVault;
-import org.datavaultplatform.common.model.RoleAssignment;
+import org.datavaultplatform.common.model.DataCreator;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -13,9 +11,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
-public class PendingDataCreatorDAOImpl implements PendingDataCreatorDAO{
+public class DataCreatorDAOImpl implements DataCreatorDAO{
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PendingDataCreatorDAOImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataCreatorDAOImpl.class);
 
     private SessionFactory sessionFactory;
 
@@ -24,10 +22,10 @@ public class PendingDataCreatorDAOImpl implements PendingDataCreatorDAO{
     }
 
     @Override
-    public void save(List<PendingDataCreator> pendingDataCreators) {
+    public void save(List<DataCreator> dataCreators) {
         Session session = this.sessionFactory.openSession();
         Transaction tx = session.beginTransaction();
-        for (PendingDataCreator pdc : pendingDataCreators) {
+        for (DataCreator pdc : dataCreators) {
             session.persist(pdc);
         }
         tx.commit();
@@ -35,28 +33,28 @@ public class PendingDataCreatorDAOImpl implements PendingDataCreatorDAO{
     }
 
     @Override
-    public PendingDataCreator findById(String Id) {
+    public DataCreator findById(String Id) {
         Session session = this.sessionFactory.openSession();
-        Criteria criteria = session.createCriteria(PendingDataCreator.class);
+        Criteria criteria = session.createCriteria(DataCreator.class);
         criteria.add(Restrictions.eq("id", Id));
-        PendingDataCreator creator = (PendingDataCreator) criteria.uniqueResult();
+        DataCreator creator = (DataCreator) criteria.uniqueResult();
         session.close();
         return creator;
     }
 
     @Override
-    public void update(PendingDataCreator pendingDataCreator) {
+    public void update(DataCreator dataCreator) {
         Session session = null;
         Transaction tx = null;
         try {
             session = this.sessionFactory.openSession();
             tx = session.beginTransaction();
-            session.update(pendingDataCreator);
+            session.update(dataCreator);
             tx.commit();
         } catch (RuntimeException e) {
             if (tx != null) {
                 tx.rollback();
-                System.out.println("PendingDataCreator.update - ROLLBACK");
+                System.out.println("DataCreator.update - ROLLBACK");
             }
             throw e;
         } finally {
@@ -68,7 +66,7 @@ public class PendingDataCreatorDAOImpl implements PendingDataCreatorDAO{
 
     @Override
     public void delete(String id) {
-        PendingDataCreator creator = findById(id);
+        DataCreator creator = findById(id);
         Session session = null;
         try {
             session = this.sessionFactory.openSession();

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminPendingVaultsController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminPendingVaultsController.java
@@ -129,11 +129,13 @@ public class AdminPendingVaultsController {
         // and convert it to create vault object like in VaultController.getPendingVault
         VaultInfo pendingVault = restService.getPendingVault(pendingVaultID);
         CreateVault cv = pendingVault.convertToCreate();
-        logger.info("Attempting to upgrade pending vault to pull vault");
+        logger.info("Attempting to upgrade pending vault to full vault");
         VaultInfo newVault = restService.addVault(cv);
-        logger.info("Completed upgrading pending vault to pull vault");
+        logger.info("Completed upgrading pending vault to full vault");
         //need to add full vault datacreators, roles etc.
         // any other new info too pure stuff billing etc.
+        // then delete the pending vault
+        restService.deletePendingVault(cv.getPendingID());
         String vaultUrl = "/vaults/" + newVault.getID() + "/";
         return "redirect:" + vaultUrl;
     }


### PR DESCRIPTION
1) Added new classes / interface DataCreatorsService, DataCreator, DataCreatorDAO and DataCreatorDAOIMpl
2) Added new method to VaultsService to process the data creators
3) Added new table sql to pending-vaults.sql
4) Updated datavault-broker-root.xml to add new beans / injections
5) Updated Vault model object to have one to many to data creator

Just the metadata that needs to be stored now when a pending vault is upgraded to full vault.

When you pull this down you need to run the new sql in pending-vaults.sql