### PR TITLE
DS-RSS212-209-20210929 Completed the changes to the billing / info / summary fieldsets

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/PendingVaultsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/PendingVaultsService.java
@@ -296,28 +296,50 @@ public class PendingVaultsService {
             vault.setSliceID(sliceID);
         }
 
-        String authoriser = createVault.getAuthoriser();
-        logger.debug("Authoriser is: '" + authoriser+ "'");
-        if (authoriser != null) {
-            vault.setAuthoriser(authoriser);
+        if (vault.getBillingType().equals(PendingVault.Billing_Type.GRANT_FUNDING)) {
+            String authoriser = createVault.getGrantAuthoriser();
+            logger.debug("Authoriser is: '" + authoriser + "'");
+            if (authoriser != null) {
+                vault.setAuthoriser(authoriser);
+            }
+
+            String schoolOrUnit = createVault.getGrantSchoolOrUnit();
+            logger.debug("schoolOrUnit is: '" + schoolOrUnit + "'");
+            if (schoolOrUnit != null) {
+                vault.setSchoolOrUnit(schoolOrUnit);
+            }
+
+            String subunit = createVault.getGrantSubunit();
+            logger.debug("Subunit is: '" + subunit + "'");
+            if (subunit != null) {
+                vault.setSubunit(subunit);
+            }
+
+            String projectID = createVault.getProjectID();
+            logger.debug("ProjectID is: '" + projectID + "'");
+            if (projectID != null) {
+                vault.setProjectID(projectID);
+            }
         }
 
-        String schoolOrUnit = createVault.getSchoolOrUnit();
-        logger.debug("schoolOrUnit is: '" + schoolOrUnit+ "'");
-        if (schoolOrUnit != null) {
-            vault.setSchoolOrUnit(schoolOrUnit);
-        }
+        if (vault.getBillingType().equals(PendingVault.Billing_Type.BUDGET_CODE)) {
+            String authoriser = createVault.getBudgetAuthoriser();
+            logger.debug("Authoriser is: '" + authoriser + "'");
+            if (authoriser != null) {
+                vault.setAuthoriser(authoriser);
+            }
 
-        String subunit = createVault.getSubunit();
-        logger.debug("Subunit is: '" + subunit+ "'");
-        if (subunit != null) {
-            vault.setSubunit(subunit);
-        }
+            String schoolOrUnit = createVault.getBudgetSchoolOrUnit();
+            logger.debug("schoolOrUnit is: '" + schoolOrUnit + "'");
+            if (schoolOrUnit != null) {
+                vault.setSchoolOrUnit(schoolOrUnit);
+            }
 
-        String projectID = createVault.getProjectID();
-        logger.debug("ProjectID is: '" + projectID+ "'");
-        if (projectID != null) {
-            vault.setProjectID(projectID);
+            String subunit = createVault.getBudgetSubunit();
+            logger.debug("Subunit is: '" + subunit + "'");
+            if (subunit != null) {
+                vault.setSubunit(subunit);
+            }
         }
 
         // this the creator of the pending vault not necessarily the prospective owner

--- a/datavault-common/src/main/java/org/datavaultplatform/common/request/CreateVault.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/request/CreateVault.java
@@ -6,8 +6,12 @@ import org.datavaultplatform.common.model.PendingVault;
 import org.jsondoc.core.annotation.ApiObject;
 import org.jsondoc.core.annotation.ApiObjectField;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @ApiObject(name = "CreateVault")
@@ -59,13 +63,21 @@ public class CreateVault {
     private String sliceID;
 
     @ApiObjectField(description = "If the billng type is grant or budget we will store an identifier for authoriser")
-    private String authoriser;
+    private String grantAuthoriser;
+    @ApiObjectField(description = "If the billng type is grant or budget we will store an identifier for authoriser")
+    private String budgetAuthoriser;
 
     @ApiObjectField(description = "If the billng type is grant or budget we will store an identifier for school / unit")
-    private String schoolOrUnit;
+    private String grantSchoolOrUnit;
+
+    @ApiObjectField(description = "If the billng type is grant or budget we will store an identifier for school / unit")
+    private String budgetSchoolOrUnit;
 
     @ApiObjectField(description = "If the billng type is grant or budget we will store an identifier for subunit")
-    private String subunit;
+    private String grantSubunit;
+
+    @ApiObjectField(description = "If the billng type is grant or budget we will store an identifier for subunit")
+    private String budgetSubunit;
 
     @ApiObjectField(description = "If the billng type is grant or budget we will store an identifier for projectID")
     private String projectID;
@@ -232,28 +244,52 @@ public class CreateVault {
         this.pendingID = pendingID;
     }
 
-    public String getAuthoriser() {
-        return this.authoriser;
+    public String getGrantAuthoriser() {
+        return this.grantAuthoriser;
     }
 
-    public void setAuthoriser(String authoriser) {
-        this.authoriser = authoriser;
+    public void setGrantAuthoriser(String grantAuthoriser) {
+        this.grantAuthoriser = grantAuthoriser;
     }
 
-    public String getSchoolOrUnit() {
-        return this.schoolOrUnit;
+    public String getBudgetAuthoriser() {
+        return this.budgetAuthoriser;
     }
 
-    public void setSchoolOrUnit(String schoolOrUnit) {
-        this.schoolOrUnit = schoolOrUnit;
+    public void setBudgetAuthoriser(String budgetAuthoriser) {
+        this.budgetAuthoriser = budgetAuthoriser;
     }
 
-    public String getSubunit() {
-        return this.subunit;
+    public String getGrantSchoolOrUnit() {
+        return this.grantSchoolOrUnit;
     }
 
-    public void setSubunit(String subunit) {
-        this.subunit = subunit;
+    public void setGrantSchoolOrUnit(String grantSchoolOrUnit) {
+        this.grantSchoolOrUnit = grantSchoolOrUnit;
+    }
+
+    public String getBudgetSchoolOrUnit() {
+        return this.budgetSchoolOrUnit;
+    }
+
+    public void setBudgetSchoolOrUnit(String budgetSchoolOrUnit) {
+        this.budgetSchoolOrUnit = budgetSchoolOrUnit;
+    }
+
+    public String getGrantSubunit() {
+        return this.grantSubunit;
+    }
+
+    public void setGrantSubunit(String grantSubunit) {
+        this.grantSubunit = grantSubunit;
+    }
+
+    public String getBudgetSubunit() {
+        return this.budgetSubunit;
+    }
+
+    public void setBudgetSubunit(String budgetSubunit) {
+        this.budgetSubunit = budgetSubunit;
     }
 
     public String getProjectID() {
@@ -313,31 +349,42 @@ public class CreateVault {
         return retVal;
     }
 
-    public String getBillingAsString() {
-        StringBuilder retVal = new StringBuilder();
-
-        if (this.billingType != null && !this.billingType.equals("")) {
-            // add billing type
-            retVal.append(this.billingType);
-            if (! this.billingType.equals("NA")) {
-                // if not N/A add [
-                retVal.append(" [");
-                // if grant type or budget code add authoriser, school/ unit, subunit and project id
-                if (this.billingType.equals("GRANT_FUNDING") || this.billingType.equals("BUDGET_CODE")) {
-                    retVal.append(this.authoriser + ",");
-                    retVal.append(this.schoolOrUnit + ",");
-                    retVal.append(this.subunit + ",");
-                    retVal.append(this.projectID);
-                }
-                // if slice add slice
-                if (this.billingType.equals("SLICE")) {
-                   retVal.append(this.sliceID);
-                }
-                retVal.append("]");
-            }
-        }
-        return retVal.toString();
-    }
+//    public String getBillingAsString() {
+//        StringBuilder retVal = new StringBuilder();
+//
+//        if (this.billingType != null && !this.billingType.equals("")) {
+//            // add billing type
+//            retVal.append(this.billingType);
+//            if (! this.billingType.equals("NA")) {
+//                // if not N/A add [
+//                retVal.append(" [");
+//                // if grant type or budget code add authoriser, school/ unit, subunit and project id
+//                if (this.billingType.equals("GRANT_FUNDING") || this.billingType.equals("BUDGET_CODE")) {
+//                    retVal.append(this.grantAuthoriser + ",");
+//                    retVal.append(this.grantSchoolOrUnit + ",");
+//                    retVal.append(this.grantSubunit + ",");
+//                    retVal.append(this.projectID);
+//                    DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd", Locale.UK);
+//                    try {
+//                        retVal.append(formatter.parse(this.grantEndDate));
+//                    } catch (ParseException|NullPointerException ex) {
+//                        // do what?
+//                    }
+//                }
+//                if (this.billingType.equals("BUDGET_CODE")) {
+//                    retVal.append(this.budgetAuthoriser + ",");
+//                    retVal.append(this.budgetSchoolOrUnit + ",");
+//                    retVal.append(this.budgetSubunit + ",");
+//                }
+//                // if slice add slice
+//                if (this.billingType.equals("SLICE")) {
+//                   retVal.append(this.sliceID);
+//                }
+//                retVal.append("]");
+//            }
+//        }
+//        return retVal.toString();
+//    }
 
     public void setDataCreators(List<String> dataCreators) { this.dataCreators = dataCreators; }
 

--- a/datavault-common/src/main/java/org/datavaultplatform/common/response/VaultInfo.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/response/VaultInfo.java
@@ -518,11 +518,23 @@ public class VaultInfo {
         if (this.getBillingType() != null) {
             cv.setBillingType(this.getBillingType().toString());
         }
-        cv.setSliceID(this.getSliceID());
-        cv.setAuthoriser(this.getAuthoriser());
-        cv.setSchoolOrUnit(this.getSchoolOrUnit());
-        cv.setSubunit(this.getSubunit());
-        cv.setProjectID(this.getProjectId());
+        if (this.getBillingType().equals(PendingVault.Billing_Type.SLICE)) {
+            cv.setSliceID(this.getSliceID());
+        }
+
+        if (this.getBillingType().equals(PendingVault.Billing_Type.GRANT_FUNDING)) {
+            cv.setGrantAuthoriser(this.getAuthoriser());
+            cv.setGrantSchoolOrUnit(this.getSchoolOrUnit());
+            cv.setGrantSubunit(this.getSubunit());
+            cv.setProjectID(this.getProjectId());
+        }
+
+        if (this.getBillingType().equals(PendingVault.Billing_Type.BUDGET_CODE)) {
+            cv.setBudgetAuthoriser(this.getAuthoriser());
+            cv.setBudgetSchoolOrUnit(this.getSchoolOrUnit());
+            cv.setBudgetSubunit(this.getSubunit());
+        }
+
         cv.setName(this.getName());
         //logger.info("Vault Description is: '" + vault.getDescription());
         cv.setDescription(this.getDescription());

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/ValidateService.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/ValidateService.java
@@ -50,24 +50,14 @@ public class ValidateService {
         }
 
         //If type GRANT_FUNDING or BUDGET_CODE
-        if (type.equals("GRANT_FUNDING") || type.equals("BUDGET_CODE")) {
+        if (type.equals("GRANT_FUNDING")) {
 
-            //Authoriser
-            String authoriser = vault.getAuthoriser();
-            if (authoriser == null || authoriser.isEmpty()) {
-                retVal.add("Authoriser missing");
-            }
-            //School / Unit
-            String schoolOrUnit = vault.getSchoolOrUnit();
-            if (schoolOrUnit == null || schoolOrUnit.isEmpty()) {
-                retVal.add("School / Unit missing");
-            }
-            //Subunit
-            String subunit = vault.getSubunit();
-            if (subunit == null || subunit.isEmpty()) {
-                retVal.add("Subunit missing");
-            }
-            return retVal;
+            return this.validateGrantBillingType(vault);
+        }
+
+        if (type.equals("BUDGET_CODE")) {
+
+            return this.validateBudgetBillingType(vault);
         }
 
         //If type SLICE
@@ -80,6 +70,57 @@ public class ValidateService {
         }
 
 
+        return retVal;
+    }
+
+    private List<String> validateBudgetBillingType(CreateVault vault) {
+        List<String> retVal = new ArrayList<>();
+
+        //Authoriser
+        String authoriser = vault.getBudgetAuthoriser();
+        if (authoriser == null || authoriser.isEmpty()) {
+            retVal.add("Authoriser missing");
+        }
+        //School / Unit
+        String schoolOrUnit = vault.getBudgetSchoolOrUnit();
+        if (schoolOrUnit == null || schoolOrUnit.isEmpty()) {
+            retVal.add("School / Unit missing");
+        }
+        //Subunit
+        String subunit = vault.getBudgetSubunit();
+        if (subunit == null || subunit.isEmpty()) {
+            retVal.add("Subunit missing");
+        }
+        return retVal;
+
+    }
+    private List<String> validateGrantBillingType(CreateVault vault) {
+        List<String> retVal = new ArrayList<>();
+
+        String authoriser = vault.getGrantAuthoriser();
+        if (authoriser == null || authoriser.isEmpty()) {
+            retVal.add("Authoriser missing");
+        }
+        //School / Unit
+        String schoolOrUnit = vault.getGrantSchoolOrUnit();
+        if (schoolOrUnit == null || schoolOrUnit.isEmpty()) {
+            retVal.add("School / Unit missing");
+        }
+        //Subunit
+        String subunit = vault.getGrantSubunit();
+        if (subunit == null || subunit.isEmpty()) {
+            retVal.add("Subunit missing");
+        }
+        // Project Title
+        String projectTitle = vault.getProjectID();
+        if (projectTitle == null || projectTitle.isEmpty()) {
+            retVal.add("Project Title missing");
+        }
+        // Grant end date
+        String grantEndDate = vault.getReviewDate();
+        if (grantEndDate == null || grantEndDate.isEmpty()) {
+            retVal.add("Review Date missing");
+        }
         return retVal;
     }
 

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/billingFieldset.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/billingFieldset.ftl
@@ -52,17 +52,17 @@
                             <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip"
                                   title="The name of someone in your School/Unit or Sub-Unit who can authorise the payment of the eIT."></span>
                         </label>
-                        <@spring.bind "vault.authoriser" />
+                        <@spring.bind "vault.grantAuthoriser" />
                         <input type="text" id="authoriser" name="${spring.status.expression}" value="${spring.status.value!""}"/>
                     </div>
                     <div class="form-group required">
                         <label class="col-sm-2 control-label">School/Unit:</label>
-                        <@spring.bind "vault.schoolOrUnit" />
+                        <@spring.bind "vault.grantSchoolOrUnit" />
                         <input type="text" id="schoolOrUnit" name="${spring.status.expression}" value="${spring.status.value!""}" />
                     </div>
                     <div class="form-group required">
                         <label class="col-sm-2 control-label">Subunit:</label>
-                        <@spring.bind "vault.subunit" />
+                        <@spring.bind "vault.grantSubunit" />
                         <input type="text" id="subunit" name="${spring.status.expression}" value="${spring.status.value!""}" />
                     </div>
                     <div class="form-group required">
@@ -93,18 +93,18 @@
                             <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip"
                                   title="The name of someone in your School/Unit or Sub-Unit who can authorise the payment of the eIT."></span>
                         </label>
-                        <@spring.bind "vault.authoriser" />
-                        <input type="text" id="authoriser" name="${spring.status.expression}" value="${spring.status.value!""}"/>
+                        <@spring.bind "vault.budgetAuthoriser" />
+                        <input type="text" id="bugdet-authoriser" name="${spring.status.expression}" value="${spring.status.value!""}"/>
                     </div>
                     <div class="form-group required">
                         <label class="col-sm-2 control-label">School/Unit:</label>
-                        <@spring.bind "vault.schoolOrUnit" />
-                        <input type="text" id="schoolOrUnit" name="${spring.status.expression}" value="${spring.status.value!""}" />
+                        <@spring.bind "vault.budgetSchoolOrUnit" />
+                        <input type="text" id="budget-schoolOrUnit" name="${spring.status.expression}" value="${spring.status.value!""}" />
                     </div>
                     <div class="form-group required">
                         <label class="col-sm-2 control-label">Subunit:</label>
-                        <@spring.bind "vault.subunit" />
-                        <input type="text" id="subunit" name="${spring.status.expression}" value="${spring.status.value!""}" />
+                        <@spring.bind "vault.budgetSubunit" />
+                        <input type="text" id="budget-subunit" name="${spring.status.expression}" value="${spring.status.value!""}" />
                     </div>
                 </div>
             </div>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/billingFieldset.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/billingFieldset.ftl
@@ -13,7 +13,7 @@
             <div class="radio">
                 <label>
                     <input type="radio" name="${spring.status.expression}" id="billing-choice-grantfunding" value="GRANT_FUNDING" <#if vault.billingType??>${(vault.billingType == 'GRANT_FUNDING')?then('checked', '')}</#if>>
-                    Grant funding [open dialog to select/specify a project and provide the grant end date for the purposes of when the eIT must be sent by.]​
+                    Grant funding ​
                 </label>
             </div>
             <div class="radio">
@@ -44,34 +44,67 @@
                     </div>
                 </div>
             </div>
-            <div id="billing-form" class="collapse">
+            <div id="grant-billing-form" class="collapse">
                 <div class="well">
                     <p>Please provide the details we should use to send your bill (your eIT) to the correct finance team.</p>
-                    <div class="form-group">
-                        <label class="col-sm-2 control-label">Authoriser*:
+                    <div class="form-group required">
+                        <label class="col-sm-2 control-label">Authoriser:
                             <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip"
                                   title="The name of someone in your School/Unit or Sub-Unit who can authorise the payment of the eIT."></span>
                         </label>
                         <@spring.bind "vault.authoriser" />
                         <input type="text" id="authoriser" name="${spring.status.expression}" value="${spring.status.value!""}"/>
                     </div>
-                    <div class="form-group">
-                        <label class="col-sm-2 control-label">School/Unit*:</label>
+                    <div class="form-group required">
+                        <label class="col-sm-2 control-label">School/Unit:</label>
                         <@spring.bind "vault.schoolOrUnit" />
                         <input type="text" id="schoolOrUnit" name="${spring.status.expression}" value="${spring.status.value!""}" />
                     </div>
-                    <div class="form-group">
-                        <label class="col-sm-2 control-label">Subunit*:</label>
+                    <div class="form-group required">
+                        <label class="col-sm-2 control-label">Subunit:</label>
                         <@spring.bind "vault.subunit" />
                         <input type="text" id="subunit" name="${spring.status.expression}" value="${spring.status.value!""}" />
                     </div>
-                    <div class="form-group">
-                        <label class="col-sm-2 control-label">ProjectId:
+                    <div class="form-group required">
+                        <label class="col-sm-2 control-label">Project Title:
                             <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip"
-                                  title="If you are planning to pay the bill from a grant, please select the Project from this list."></span>
+                                  title="If you are planning to pay the bill from a grant, please enter the Project Title."></span>
                         </label>
                         <@spring.bind "vault.projectID" />
                         <input type="text" id="projectID" name="${spring.status.expression}" value="${spring.status.value!""}" />
+                    </div>
+                    <div class="form-group required">
+                        <label  for="billingGrantEndDate" class="col-sm-2 control-label">
+                            Grant End Date:<span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip"
+                                                 title="This information will assist the university in ensuring the archive is kept for at least the minimum amount of time required by the funder(s). This field should be left blank if there is no grant associated with the work.&nbsp;"></span>
+                        </label>
+
+                        <@spring.bind "vault.grantEndDate" />
+                        <input id="billingGrantEndDate" class="form-control date-picker" placeholder="yyyy-mm-dd" name="${spring.status.expression}"
+                               value="${spring.status.value!""}"/>
+                    </div>
+                </div>
+            </div>
+            <div id="budget-billing-form" class="collapse">
+                <div class="well">
+                    <p>Please provide the details we should use to send your bill (your eIT) to the correct finance team.</p>
+                    <div class="form-group required">
+                        <label class="col-sm-2 control-label">Authoriser:
+                            <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip"
+                                  title="The name of someone in your School/Unit or Sub-Unit who can authorise the payment of the eIT."></span>
+                        </label>
+                        <@spring.bind "vault.authoriser" />
+                        <input type="text" id="authoriser" name="${spring.status.expression}" value="${spring.status.value!""}"/>
+                    </div>
+                    <div class="form-group required">
+                        <label class="col-sm-2 control-label">School/Unit:</label>
+                        <@spring.bind "vault.schoolOrUnit" />
+                        <input type="text" id="schoolOrUnit" name="${spring.status.expression}" value="${spring.status.value!""}" />
+                    </div>
+                    <div class="form-group required">
+                        <label class="col-sm-2 control-label">Subunit:</label>
+                        <@spring.bind "vault.subunit" />
+                        <input type="text" id="subunit" name="${spring.status.expression}" value="${spring.status.value!""}" />
                     </div>
                 </div>
             </div>

--- a/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
+++ b/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
@@ -17,9 +17,16 @@ $(document).ready(function(){
     });
 
     $( "#grantEndDate" ).datepicker();
+    $( "#billingGrantEndDate" ).datepicker();
     $( "#reviewDate" ).datepicker({
         minDate: '+1m'
     });
+
+    $( "#billingGrantEndDate" ).change(function() {
+        $("#grantEndDate").prop("placeholder", $(this).val());
+        $("#grantEndDate").text($(this).val());
+        $("#grantEndDate").prop("disabled", true);
+    }).trigger('change');
 
     $("#affirmation-check").change(function(){
         $(this).parents("fieldset").children(".next").prop( "disabled", !$(this).is(":checked") );
@@ -73,16 +80,16 @@ $(document).ready(function(){
 
     $("#billing-choice-grantfunding").change(function(){
         if($(this).is(":checked")){
-            $('.collapse').not('#billing-form').collapse('hide');
-            $('#billing-form').collapse('show');
+            $('.collapse').not('#grant-billing-form').collapse('hide');
+            $('#grant-billing-form').collapse('show');
             $(this).parents("fieldset").children(".next").prop( "disabled", false );
         }
     }).trigger('change');  ;
 
     $("#billing-choice-budgetcode").change(function(){
         if($(this).is(":checked")) {
-            $('.collapse').not('#billing-form').collapse('hide');
-            $('#billing-form').collapse('show');
+            $('.collapse').not('#budget-billing-form').collapse('hide');
+            $('#budget-billing-form').collapse('show');
             $(this).parents("fieldset").children(".next").prop( "disabled", false );
         }
     }).trigger('change');  ;

--- a/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
+++ b/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
@@ -22,10 +22,20 @@ $(document).ready(function(){
         minDate: '+1m'
     });
 
+    // if billingtype changes blank all billing fields (remember to fix date on info page)
     $( "#billingGrantEndDate" ).change(function() {
-        $("#grantEndDate").prop("placeholder", $(this).val());
-        $("#grantEndDate").text($(this).val());
-        $("#grantEndDate").prop("disabled", true);
+        // :todo make sure info version of field is only disabled if the billing one has a valid value
+        var dateResult = ($(this).val().trim() === '');
+        var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
+
+        if (dateResult === false && grantChecked === true) {
+            $("#grantEndDate").prop("placeholder", $(this).val());
+            $("#grantEndDate").text($(this).val());
+            $("#grantEndDate").prop("disabled", true);
+        } else {
+            $("#grantEndDate").prop("disabled", false);
+            $("#grantEndDate").prop("placeholder", "yyyy-mm-dd");
+        }
     }).trigger('change');
 
     $("#affirmation-check").change(function(){
@@ -74,11 +84,16 @@ $(document).ready(function(){
     }).trigger('change');
 
     $("#billing-choice-na").change(function(){
+        clearBillingOptions();
+
         $('.collapse').collapse('hide');
         $(this).parents("fieldset").children(".next").prop( "disabled", false );
     }).trigger('change');  ;
 
     $("#billing-choice-grantfunding").change(function(){
+
+        clearBillingOptions();
+
         if($(this).is(":checked")){
             $('.collapse').not('#grant-billing-form').collapse('hide');
             $('#grant-billing-form').collapse('show');
@@ -87,6 +102,9 @@ $(document).ready(function(){
     }).trigger('change');  ;
 
     $("#billing-choice-budgetcode").change(function(){
+
+        clearBillingOptions();
+
         if($(this).is(":checked")) {
             $('.collapse').not('#budget-billing-form').collapse('hide');
             $('#budget-billing-form').collapse('show');
@@ -95,6 +113,9 @@ $(document).ready(function(){
     }).trigger('change');  ;
 
     $("#billing-choice-slice").change(function(){
+
+        clearBillingOptions();
+
         if($(this).is(":checked")) {
             $('.collapse').not('#slice-form').collapse('hide');
             $('#slice-form').collapse('show');
@@ -242,6 +263,47 @@ $(document).ready(function(){
         $('#submitAction').val($(this).attr('value'));
     });
 
+    function clearBillingOptions() {
+        // enable or disable the grant end date field on the info fieldset
+        var dateResult = ($("#billingGrantEndDate").val().trim() === '');
+        var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
+
+        if (dateResult === false && grantChecked === true) {
+            $("#grantEndDate").prop("placeholder", $("#billingGrantEndDate").val());
+            $("#grantEndDate").text($("#billingGrantEndDate").val());
+            $("#grantEndDate").prop("disabled", true);
+        } else {
+            $("#grantEndDate").prop("disabled", false);
+            $("#grantEndDate").prop("placeholder", "yyyy-mm-dd");
+        }
+
+        // clear the unused fieldsets
+        var naChecked = ($("#billing-choice-na").is(":checked"));
+        var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
+        var budgetChecked = ($("#billing-choice-budgetcode").is(":checked"));
+        var sliceChecked = ($("#billing-choice-slice").is(":checked"));
+        // if billing type is not grant clear fieldset
+        if (naChecked === true) {
+            $("#grant-billing-form input").val("");
+            $("#budget-billing-form input").val("");
+            $("#slice-form input").val("");
+        }
+        if (grantChecked === true) {
+            $("#budget-billing-form input").val("");
+            $("#slice-form input").val("");
+        }
+
+        if (budgetChecked === true) {
+            $("#grant-billing-form input").val("");
+            $("#slice-form input").val("");
+        }
+
+        if (sliceChecked === true) {
+            $("#grant-billing-form input").val("");
+            $("#budget-billing-form input").val("");
+        }
+    }
+
     function populateSummaryPage() {
     	console.log("populateSummaryPage()");
     	// Check if an element with id="summary-fieldset" currently exists,
@@ -255,7 +317,12 @@ $(document).ready(function(){
     	  $("#summary-vaultName").text($("#vaultName").val());
     	  $("#summary-description").text($("#description").val());
     	  $("#summary-policyID").text($("#policyID option:selected").text());
-    	  $("#summary-grantEndDate").text($("#grantEndDate").val());
+    	  var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
+    	  if (grantChecked === true) {
+              $("#summary-grantEndDate").text($("#billingGrantEndDate").val());
+          } else {
+              $("#summary-grantEndDate").text($("#grantEndDate").val());
+          }
           $("#summary-groupID").text($("#groupID option:selected").text());
           $("#summary-reviewDate").text($("#reviewDate").val());
           // remove line breaks from string with replace(/(\r\n|\n|\r)/gm, "") and need to trim


### PR DESCRIPTION
You can now enter Grant End data and project title in addition to the previous fields for the grant billing type, the other types have the expected fields now too.
I've added JS so that the grant end date field in the info fieldset is populated and disabled if it has already been completed in the billing fieldset it is also reset / enabled if you go back and change the billing type
I've also added JS so the unused billing fields are cleared if you have entered some data for one billing type then changed to another.

As far as I can tell everything works as expected including the summary and view pending vault page after completion

1) Updated billingFieldset.ftl so that authoriser, school and subunit know have billing and grant versions instead of sharing ids
2) Added new billing and grant versions of the relevant fields to CreateVault.java
3) Updated VaultInfo, ValidateService & PendingVaultsService to work with these changes
4) Added new JS to new-create-prototype to handle the enabling / disabling of fields if the billing version of grant end date is used