### PR TITLE
DS-RSS212 199 20211025 Update billing storage and admin billing pages to handle new metadata values

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/VaultsController.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/VaultsController.java
@@ -7,7 +7,6 @@ import org.datavaultplatform.common.event.roles.CreateRoleAssignment;
 import org.datavaultplatform.common.event.roles.OrphanVault;
 import org.datavaultplatform.common.event.roles.TransferVaultOwnership;
 import org.datavaultplatform.common.event.vault.Create;
-import org.datavaultplatform.common.event.vault.Pending;
 import org.datavaultplatform.common.event.vault.UpdatedDescription;
 import org.datavaultplatform.common.event.vault.UpdatedName;
 import org.datavaultplatform.common.model.*;
@@ -518,21 +517,6 @@ public class VaultsController {
             throw new Exception("User '" + userID + "' does not exist");
         }
         vault.setUser(user);
-        //String datasetId = createVault.getDatasetID();
-        //Dataset dataset = externalMetadataService.getCachedDataset(datasetId);
-
-        //if (dataset == null) {
-        //    dataset = externalMetadataService.getDataset(datasetId);
-        //    if (dataset == null) {
-        //        logger.error("Dataset metadata record '" + datasetId + "' does not exist");
-        //        throw new Exception("Dataset metadata record '" + datasetId + "' does not exist");
-        //    }
-
-        //    externalMetadataService.addCachedDataset(dataset);
-        //}
-        //vault.setDataset(dataset);
-        //vault.setSnapshot(externalMetadataService.getDatasetContent(datasetId));
-        //vault.setProjectId(externalMetadataService.getPureProjectId(dataset.getID()));
 
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
         try {
@@ -550,18 +534,11 @@ public class VaultsController {
         }
 
         vaultsService.addVault(vault);
-
-        //RoleAssignment dataOwnerRoleAssignment = new RoleAssignment();
-        //dataOwnerRoleAssignment.setUserId(userID);
-        //dataOwnerRoleAssignment.setVaultId(vault.getID());
-        //dataOwnerRoleAssignment.setRole(permissionsService.getDataOwner());
-        //permissionsService.createRoleAssignment(dataOwnerRoleAssignment);
-
         vaultsService.addDepositorRoles(createVault, vault.getID());
         vaultsService.addOwnerRole(createVault, vault.getID(), userID);
         vault = vaultsService.processDataCreatorParams(createVault, vault);
         vaultsService.addNDMRoles(createVault, vault.getID());
-        //pendingVaultsService.addCreator(createVault, userID, vault.getId());
+        vaultsService.addBillingInfo(createVault, vault);
 
         // TODO: Add new Pending Vault created event that includes the creators name as that will be lost when the vault is upgraded
         //Pending pendingEvent = new Pending(createVault.getPendingID());
@@ -577,7 +554,6 @@ public class VaultsController {
         vaultEvent.setUser(usersService.getUser(userID));
         vaultEvent.setAgentType(Agent.AgentType.BROKER);
         vaultEvent.setAgent(clientsService.getClientByApiKey(clientKey).getName());
-
         eventService.addEvent(vaultEvent);
 
         // Check the retention policy of the newly created vault

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/admin/BillingController.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/admin/BillingController.java
@@ -9,6 +9,7 @@ import org.datavaultplatform.broker.services.BillingService;
 import org.datavaultplatform.broker.services.ExternalMetadataService;
 import org.datavaultplatform.broker.services.VaultsService;
 import org.datavaultplatform.common.model.BillingInfo;
+import org.datavaultplatform.common.model.PendingVault;
 import org.datavaultplatform.common.model.Vault;
 import org.datavaultplatform.common.response.BillingInformation;
 import org.datavaultplatform.common.response.VaultInfo;
@@ -92,6 +93,9 @@ public class BillingController {
     		if(billinginfo == null) {
     			billinginfo =  new BillingInfo();
     		}
+    		if (billinginfo.getBillingType() == null) {
+    			billinginfo.setBillingType(PendingVault.Billing_Type.ORIG);
+			}
     		billinginfo.setAmountBilled(billingDetails.getAmountBilled());
     		billinginfo.setAmountToBeBilled(billingDetails.getAmountToBeBilled());
     		billinginfo.setBudgetCode(billingDetails.getBudgetCode());

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/VaultsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/VaultsService.java
@@ -1,5 +1,6 @@
 package org.datavaultplatform.broker.services;
 
+import java.math.BigDecimal;
 import java.util.*;
 
 import org.datavaultplatform.common.model.*;
@@ -20,6 +21,8 @@ public class VaultsService {
 
     private DataCreatorsService dataCreatorsService;
 
+    private BillingService billingService;
+
     public void setRolesAndPermissionsService(RolesAndPermissionsService rolesAndPermissionsService) {
         this.rolesAndPermissionsService = rolesAndPermissionsService;
     }
@@ -33,6 +36,8 @@ public class VaultsService {
     }
 
     public void setDataCreatorsService(DataCreatorsService dataCreatorsService) { this.dataCreatorsService = dataCreatorsService; }
+
+    public void setBillingService(BillingService billingService) { this.billingService = billingService; }
 
     public List<Vault> getVaults() {
         return vaultDAO.list();
@@ -237,5 +242,34 @@ public class VaultsService {
                 }
             }
         }
+    }
+
+    public void addBillingInfo(CreateVault createVault, Vault vault) {
+        BillingInfo billinginfo =  new BillingInfo();
+        billinginfo.setAmountBilled(new BigDecimal(0));
+        billinginfo.setAmountToBeBilled(new BigDecimal(0));
+        billinginfo.setVault(vault);
+        String billingType = createVault.getBillingType();
+
+        PendingVault.Billing_Type enumBT = PendingVault.Billing_Type.valueOf(billingType);
+        billinginfo.setBillingType(enumBT);
+
+        if (enumBT.equals(PendingVault.Billing_Type.GRANT_FUNDING)) {
+            billinginfo.setContactName(createVault.getGrantAuthoriser());
+            billinginfo.setSchool(createVault.getGrantSchoolOrUnit());
+            billinginfo.setSubUnit(createVault.getGrantSubunit());
+            billinginfo.setProjectTitle(createVault.getProjectID());
+        }
+
+        if (enumBT.equals(PendingVault.Billing_Type.BUDGET_CODE)) {
+            billinginfo.setContactName(createVault.getBudgetAuthoriser());
+            billinginfo.setSchool(createVault.getBudgetSchoolOrUnit());
+            billinginfo.setSubUnit(createVault.getBudgetSubunit());
+        }
+
+        if (enumBT.equals(PendingVault.Billing_Type.SLICE)) {
+            billinginfo.setSliceID(createVault.getSliceID());
+        }
+        billingService.saveOrUpdateVault(billinginfo);
     }
 }

--- a/datavault-broker/src/main/resources/release-sql/5.0.0/pending-vaults.sql
+++ b/datavault-broker/src/main/resources/release-sql/5.0.0/pending-vaults.sql
@@ -52,16 +52,8 @@ ALTER TABLE Vaults add column notes TEXT;
 ALTER TABLE Vaults add column pureLink bit not null default false;
 ALTER TABLE Vaults add column contact TEXT;
 
-ALTER TABLE BillingInfo add column billingType TEXT NOT NULL default 'NA';
+ALTER TABLE BillingInfo add column billingType TEXT NOT NULL;
 ALTER TABLE BillingInfo add column sliceID TEXT;
-ALTER TABLE BillingInfo add column projectTitle TEXT
-
-
-    @Column(name = "billingType", nullable = false, columnDefinition = "TEXT", length=10)
-    private PendingVault.Billing_Type billingType;
-
-@Column(name = "sliceID", nullable = true, columnDefinition = "TEXT", length=40)
-	private String sliceID;
-
-@Column(name = "projectTitle", nullable = true, columnDefinition = "TEXT", length=400)
-	private String projectTitle;
+ALTER TABLE BillingInfo add column projectTitle TEXT;
+/* might have to drop the not null and add back in do do this */
+update BillingInfo set billingType = '4' where billingType = '';

--- a/datavault-broker/src/main/resources/release-sql/5.0.0/pending-vaults.sql
+++ b/datavault-broker/src/main/resources/release-sql/5.0.0/pending-vaults.sql
@@ -51,3 +51,17 @@ ALTER TABLE Vaults add column estimate TEXT;
 ALTER TABLE Vaults add column notes TEXT;
 ALTER TABLE Vaults add column pureLink bit not null default false;
 ALTER TABLE Vaults add column contact TEXT;
+
+ALTER TABLE BillingInfo add column billingType TEXT NOT NULL default 'NA';
+ALTER TABLE BillingInfo add column sliceID TEXT;
+ALTER TABLE BillingInfo add column projectTitle TEXT
+
+
+    @Column(name = "billingType", nullable = false, columnDefinition = "TEXT", length=10)
+    private PendingVault.Billing_Type billingType;
+
+@Column(name = "sliceID", nullable = true, columnDefinition = "TEXT", length=40)
+	private String sliceID;
+
+@Column(name = "projectTitle", nullable = true, columnDefinition = "TEXT", length=400)
+	private String projectTitle;

--- a/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-root.xml
+++ b/datavault-broker/src/main/webapp/WEB-INF/datavault-broker-root.xml
@@ -42,6 +42,7 @@
         <property name="rolesAndPermissionsService" ref="rolesAndPermissionsService" />
         <property name="retentionPoliciesService" ref="retentionPoliciesService" />
         <property name="dataCreatorsService" ref="dataCreatorsService" />
+        <property name="billingService" ref="billingService" />
     </bean>
 
     <bean id="pendingVaultsService" class="org.datavaultplatform.broker.services.PendingVaultsService">

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/BillingInfo.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/BillingInfo.java
@@ -53,6 +53,15 @@ public class BillingInfo {
     
 	@Column(name = "school", nullable = true, columnDefinition = "TEXT", length=400)
     private String school;
+
+	@Column(name = "billingType", nullable = false, columnDefinition = "TEXT", length=10)
+	private PendingVault.Billing_Type billingType;
+
+	@Column(name = "sliceID", nullable = true, columnDefinition = "TEXT", length=40)
+	private String sliceID;
+
+	@Column(name = "projectTitle", nullable = true, columnDefinition = "TEXT", length=400)
+	private String projectTitle;
 	
 	@OneToOne
 	@JoinColumn(name="vaultID", nullable = false)
@@ -110,6 +119,31 @@ public class BillingInfo {
 	public void setVault(Vault vault) {
 		this.vault = vault;
 	}
+
+	public PendingVault.Billing_Type getBillingType() {
+		return this.billingType;
+	}
+
+	public void setBillingType(PendingVault.Billing_Type billingType) {
+		this.billingType = billingType;
+	}
+
+	public String getSliceID() {
+		return this.sliceID;
+	}
+
+	public void setSliceID(String sliceID) {
+		this.sliceID = sliceID;
+	}
+
+	public String getProjectTitle() {
+		return this.projectTitle;
+	}
+
+	public void setProjectTitle(String projectTitle) {
+		this.projectTitle = projectTitle;
+	}
+
 	public BillingInfo() {}
  
     public String getID() { 

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/BillingInfo.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/BillingInfo.java
@@ -166,7 +166,10 @@ public class BillingInfo {
                 amountToBeBilled,
                 amountBilled,
                 vault.getProjectId(),
-                vault.getName()
+                vault.getName(),
+				sliceID,
+				projectTitle,
+				billingType
             );
     }
      

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/PendingVault.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/PendingVault.java
@@ -30,7 +30,8 @@ public class PendingVault {
         NA,
         GRANT_FUNDING,
         BUDGET_CODE,
-        SLICE
+        SLICE,
+        ORIG
     }
     // Vault Identifier
     @Id

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/Vault.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/Vault.java
@@ -407,7 +407,10 @@ public class Vault {
                 billinginfo != null? billinginfo.getAmountToBeBilled() : null,
                 billinginfo != null? billinginfo.getAmountBilled() : null,
                 projectId,
-                name
+                name,
+                billinginfo != null? billinginfo.getSliceID() : null,
+                billinginfo != null? billinginfo.getProjectTitle() : null,
+                billinginfo != null? billinginfo.getBillingType() : null
             );
     }
     

--- a/datavault-common/src/main/java/org/datavaultplatform/common/response/BillingInformation.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/response/BillingInformation.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.util.Date;
 
+import org.datavaultplatform.common.model.PendingVault;
 import org.jsondoc.core.annotation.ApiObject;
 import org.jsondoc.core.annotation.ApiObjectField;
 
@@ -19,7 +20,9 @@ public class BillingInformation {
     @ApiObjectField(description = "The vault ID")
     private String vaultID;
 
-   
+	@ApiObjectField(description = "The Billing type")
+	private PendingVault.Billing_Type billingType;
+
     @ApiObjectField(description = "Billing Details Contact Name")
     private String contactName;
         
@@ -28,9 +31,15 @@ public class BillingInformation {
 
     @ApiObjectField(description = "The Billing Subunit")
     private String subUnit;
+
+	@ApiObjectField(description = "The Billing Project title")
+	private String projectTitle;
     
     @ApiObjectField(description = "To know if the user uses BudgetCode")
     private Boolean budgetCode;
+
+	@ApiObjectField(description = "The Billing SliceID")
+	private String sliceID;
     
     @ApiObjectField(description = "The comments entered by Admin")
     private String specialComments;
@@ -67,7 +76,9 @@ public class BillingInformation {
     }
 
 	public BillingInformation(String id, String vaultID, String contactName, String school, String subUnit, Boolean budgetCode,
-			String specialComments, BigDecimal amountToBeBilled, BigDecimal amountBilled, long vaultSize, Date reviewDate, Date creationTime, String vaultName,String projectId,String userName) {
+			String specialComments, BigDecimal amountToBeBilled, BigDecimal amountBilled, long vaultSize, Date reviewDate,
+							  Date creationTime, String vaultName,String projectId,String userName, String sliceID,
+							  String projectTitle, PendingVault.Billing_Type billingType) {
     	this.id = id;        
         this.vaultID = vaultID;    
         this.contactName = contactName; 
@@ -81,12 +92,16 @@ public class BillingInformation {
         this.reviewDate = reviewDate;       
         this.creationTime = creationTime;
         this.vaultName = vaultName;
-        this.projectId= projectId;
-        this.userName= userName;
+        this.projectId = projectId;
+        this.userName = userName;
+        this.sliceID = sliceID;
+        this.projectTitle = projectTitle;
+        this.billingType = billingType;
 	}
 	
 	public BillingInformation(String id, String vaultID, String contactName, String school, String subUnit, Boolean budgetCode,
-			String specialComments, BigDecimal amountToBeBilled, BigDecimal amountBilled, String projectId, String vaultName) {
+			String specialComments, BigDecimal amountToBeBilled, BigDecimal amountBilled, String projectId, String vaultName,
+							  String sliceID, String projectTitle, PendingVault.Billing_Type billingType) {
     	this.id = id;        
         this.vaultID = vaultID;    
         this.contactName = contactName; 
@@ -98,6 +113,9 @@ public class BillingInformation {
         this.amountBilled = amountBilled;
         this.projectId= projectId;
         this.vaultName = vaultName;
+        this.sliceID = sliceID;
+        this.projectTitle = projectTitle;
+        this.billingType = billingType;
 	}
 
     public String getUserName() {
@@ -226,6 +244,30 @@ public class BillingInformation {
 
 	public void setProjectSize(long projectSize) {
 		this.projectSize = projectSize;
+	}
+
+	public PendingVault.Billing_Type getBillingType() {
+		return billingType;
+	}
+
+	public void setBillingType(PendingVault.Billing_Type billingType) {
+		this.billingType = billingType;
+	}
+
+	public String getProjectTitle() {
+		return projectTitle;
+	}
+
+	public void setProjectTitle(String projectTitle) {
+		this.projectTitle = projectTitle;
+	}
+
+	public String getSliceID() {
+		return sliceID;
+	}
+
+	public void setSliceID(String sliceID) {
+		this.sliceID = sliceID;
 	}
 	
 	public String getProjectSizeStr() {

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminBillingController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminBillingController.java
@@ -167,6 +167,10 @@ public class AdminBillingController {
             return retVal;
         }
 
+        if (type.equals(PendingVault.Billing_Type.ORIG)) {
+            retVal = "admin/billing/billingDetails";
+        }
+
         if (type.equals(PendingVault.Billing_Type.NA)) {
             retVal = "admin/billing/billingDetailsNA";
         }

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminBillingController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminBillingController.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javax.servlet.http.HttpServletResponse;
 
+import org.datavaultplatform.common.model.PendingVault;
 import org.datavaultplatform.common.response.BillingInformation;
 import org.datavaultplatform.common.response.VaultInfo;
 import org.datavaultplatform.common.response.VaultsData;
@@ -133,8 +134,19 @@ public class AdminBillingController {
     @RequestMapping(value = "/admin/billing/{vaultId}", method = RequestMethod.GET)
     public String retrieveBillingInfo(ModelMap model, @PathVariable("vaultId") String vaultId) {
     	BillingInformation billingDetails = restService.getVaultBillingInfo(vaultId);
-        model.addAttribute("billingDetails", billingDetails);       
-        return "admin/billing/billingDetails";
+        model.addAttribute("billingDetails", billingDetails);
+        String billingPage = "admin/billing/billingDetailsNA";
+
+        /*if (billingDetails.getBillingType().equals(PendingVault.Billing_Type.GRANT_FUNDING)) {
+            billingPage = "admin/billing/billingDetailsGrant";
+        }
+        if (billingDetails.getBillingType().equals(PendingVault.Billing_Type.BUDGET_CODE)) {
+            billingPage = "admin/billing/billingDetailsBudget";
+        }
+        if (billingDetails.getBillingType().equals(PendingVault.Billing_Type.SLICE)) {
+            billingPage = "admin/billing/billingDetailsSlice";
+        }*/
+        return this.getBillingInfoPage(billingDetails.getBillingType());
     }
    
     @RequestMapping(value = "/admin/billing/updateBillingDetails", method = RequestMethod.POST)
@@ -143,7 +155,32 @@ public class AdminBillingController {
             ) throws Exception {
     	 System.out.println("-----------getBudgetCode---------"+billingDetails.getBudgetCode());
     	restService.updateBillingInfo(billingDetails.getVaultID(),billingDetails);
-    	return "admin/billing/billingDetails";
+    	//return "admin/billing/billingDetails";
+        return this.getBillingInfoPage(billingDetails.getBillingType());
+    }
+
+    private String getBillingInfoPage(PendingVault.Billing_Type type) {
+        String retVal = "admin/billing/billingDetails";
+
+        // so the old pre new interface vaults still go to the old page
+        if (type == null) {
+            return retVal;
+        }
+
+        if (type.equals(PendingVault.Billing_Type.NA)) {
+            retVal = "admin/billing/billingDetailsNA";
+        }
+
+        if (type.equals(PendingVault.Billing_Type.GRANT_FUNDING)) {
+            retVal = "admin/billing/billingDetailsGrant";
+        }
+        if (type.equals(PendingVault.Billing_Type.BUDGET_CODE)) {
+            retVal = "admin/billing/billingDetailsBudget";
+        }
+        if (type.equals(PendingVault.Billing_Type.SLICE)) {
+            retVal = "admin/billing/billingDetailsSlice";
+        }
+        return retVal;
     }
 
 	

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/billing/billingDetails.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/billing/billingDetails.ftl
@@ -121,6 +121,9 @@
                     <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                     <input type="hidden" name="vaultID" value="${billingDetails.getVaultID()}"/>
 					<input type="hidden" name="vaultName" value="${billingDetails.getVaultName()}"/>
+                    <#if billingDetails.getBillingType()??>
+                    <input type="hidden" name="billingType" value="${billingDetails.getBillingType()}"/>
+                    </#if>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                         <button type="submit" id="update-billingDetails-btn" class="btn btn-primary btn-ok">Save</button>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/billing/billingDetailsBudget.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/billing/billingDetailsBudget.ftl
@@ -1,0 +1,128 @@
+<#import "*/layout/defaultlayout.ftl" as layout>
+<#global nav="admin">
+<#import "/spring.ftl" as spring />
+<@layout.vaultLayout>
+    <div class="container">
+
+        <ol class="breadcrumb">
+            <li><a
+                        href="${springMacroRequestContext.getContextPath()}/admin/"><b>Administration</b></a></li>
+            <li><a
+                        href="${springMacroRequestContext.getContextPath()}/admin/billing"><b>Billing</b></a></li>
+            <li class="active"><b>BillingDetails:</b>${billingDetails.vaultName?html}</li>
+        </ol>
+        <div class="panel panel-uoe-low">
+            <div class="panel-body">
+                <h2>Billing Details (Budget): <small>${billingDetails.vaultName?html}</small></h2>
+
+                <br/>
+                <table class="table table-sm">
+                    <tbody>
+                    <tr>
+                        <th scope="col">Authoriser</th>
+                        <td><#if billingDetails.getContactName()??>${billingDetails.contactName?html}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">School/Unit</th>
+                        <td><#if billingDetails.getSchool()??>${billingDetails.school?html}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Subunit</th>
+                        <td><#if billingDetails.getSubUnit()??>${billingDetails.subUnit}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Project Id</th>
+                        <td><#if billingDetails.getProjectId()??>${billingDetails.projectId}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Amount to be billed</th>
+                        <td><#if billingDetails.getAmountToBeBilled()??>${billingDetails.getAmountToBeBilled()?html}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Amount billed</th>
+                        <td><#if billingDetails.getAmountBilled()??>${billingDetails.getAmountBilled()?html}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Special arrangement comments</th>
+                        <td><#if billingDetails.getSpecialComments()??>${billingDetails.getSpecialComments()?html}<#else> </#if></td>
+                    </tr>
+                    </tbody>
+                </table>
+
+                <div class="btn-toolbar pull-right">
+                    <button type="button" class="btn btn-default pull-right" data-toggle="modal" data-target="#update-billingDetails">
+                        Edit
+                    </button>
+                </div>
+                <div id="update-billingDetails" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="updateBillingDetails" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <form id="update-billingDetails-form" class="form" role="form" action="${springMacroRequestContext.getContextPath()}/admin/billing/updateBillingDetails" method="post">
+                                <div class="modal-header">
+                                    <h4 class="modal-title" id="addDataManger">Billing Details</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="form-group">
+                                        <label class="control-label">Authoriser:</label>
+                                        <@spring.bind "billingDetails.contactName" />
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="contactName" maxlength="400"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">School/Unit:</label>
+                                        <@spring.bind "billingDetails.school" />
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="school" maxlength="400"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">Subunit:</label>
+                                        <@spring.bind "billingDetails.subUnit" />
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="subunit" maxlength="400" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">ProjectId:</label>
+                                        <@spring.bind "billingDetails.projectId" />
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="projectId" maxlength="400"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">Amount to be billed:(Please enter the amount in pounds (and pence  if applicable) without any symbols, do not use commas)</label>
+                                        <@spring.bind "billingDetails.amountToBeBilled" />:
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="amountToBeBilled" maxlength="400" pattern="[0-9]+(\.[0-9][0-9]?)?"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">Amount billed:(Please enter the amount in pounds (and pence  if applicable) without any symbols, do not use commas)</label>
+                                        <@spring.bind "billingDetails.amountBilled" />
+                                        <input type="text" class="form-control" pattern="[0-9]+(\.[0-9][0-9]?)?" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" maxlength="400" id="amountBilled"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">Special arrangements comments:</label>
+                                        <@spring.bind "billingDetails.specialComments" />
+                                        <textarea type="text" class="form-control" name="${spring.status.expression}"
+                                                  value="${spring.status.value!""}" id="comments" rows="4" cols="60" maxlength="400" ><#if billingDetails.getSpecialComments()??>${billingDetails.getSpecialComments()}</#if></textarea>
+                                    </div>
+                                </div>
+
+                                <input type="hidden" id="submitAction" name="action" value="submit"/>
+                                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+                                <input type="hidden" name="vaultID" value="${billingDetails.getVaultID()}"/>
+                                <input type="hidden" name="vaultName" value="${billingDetails.getVaultName()}"/>
+                                <input type="hidden" name="billingType" value="${billingDetails.getBillingType()}"/>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                                    <button type="submit" id="update-billingDetails-btn" class="btn btn-primary btn-ok">Save</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <input type="hidden" name="${_csrf.parameterName}"
+               value="${_csrf.token}" />
+    </div>
+</@layout.vaultLayout>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/billing/billingDetailsGrant.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/billing/billingDetailsGrant.ftl
@@ -1,0 +1,138 @@
+<#import "*/layout/defaultlayout.ftl" as layout>
+<#global nav="admin">
+<#import "/spring.ftl" as spring />
+<@layout.vaultLayout>
+    <div class="container">
+
+        <ol class="breadcrumb">
+            <li><a
+                        href="${springMacroRequestContext.getContextPath()}/admin/"><b>Administration</b></a></li>
+            <li><a
+                        href="${springMacroRequestContext.getContextPath()}/admin/billing"><b>Billing</b></a></li>
+            <li class="active"><b>BillingDetails:</b>${billingDetails.vaultName?html}</li>
+        </ol>
+        <div class="panel panel-uoe-low">
+            <div class="panel-body">
+                <h2>Billing Details (Grant): <small>${billingDetails.vaultName?html}</small></h2>
+
+                <br/>
+                <table class="table table-sm">
+                    <tbody>
+                    <tr>
+                        <th scope="col">Authoriser</th>
+                        <td><#if billingDetails.getContactName()??>${billingDetails.contactName?html}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">School/Unit</th>
+                        <td><#if billingDetails.getSchool()??>${billingDetails.school?html}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Subunit</th>
+                        <td><#if billingDetails.getSubUnit()??>${billingDetails.subUnit}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Project Title</th>
+                        <td><#if billingDetails.getProjectTitle()??>${billingDetails.projectTitle}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Project Id</th>
+                        <td><#if billingDetails.getProjectId()??>${billingDetails.projectId}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Amount to be billed</th>
+                        <td><#if billingDetails.getAmountToBeBilled()??>${billingDetails.getAmountToBeBilled()?html}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Amount billed</th>
+                        <td><#if billingDetails.getAmountBilled()??>${billingDetails.getAmountBilled()?html}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Special arrangement comments</th>
+                        <td><#if billingDetails.getSpecialComments()??>${billingDetails.getSpecialComments()?html}<#else> </#if></td>
+                    </tr>
+                    </tbody>
+                </table>
+
+                <div class="btn-toolbar pull-right">
+                    <button type="button" class="btn btn-default pull-right" data-toggle="modal" data-target="#update-billingDetails">
+                        Edit
+                    </button>
+                </div>
+                <div id="update-billingDetails" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="updateBillingDetails" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <form id="update-billingDetails-form" class="form" role="form" action="${springMacroRequestContext.getContextPath()}/admin/billing/updateBillingDetails" method="post">
+                                <div class="modal-header">
+                                    <h4 class="modal-title" id="addDataManger">Billing Details</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="form-group">
+                                        <label class="control-label">Authoriser:</label>
+                                        <@spring.bind "billingDetails.contactName" />
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="contactName" maxlength="400"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">School/Unit:</label>
+                                        <@spring.bind "billingDetails.school" />
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="school" maxlength="400"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">Subunit:</label>
+                                        <@spring.bind "billingDetails.subUnit" />
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="subunit" maxlength="400" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">ProjectTitle:</label>
+                                        <@spring.bind "billingDetails.projectTitle" />
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="projectTitle" maxlength="400"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">ProjectId:</label>
+                                        <@spring.bind "billingDetails.projectId" />
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="projectId" maxlength="400"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">Amount to be billed:(Please enter the amount in pounds (and pence  if applicable) without any symbols, do not use commas)</label>
+                                        <@spring.bind "billingDetails.amountToBeBilled" />:
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="amountToBeBilled" maxlength="400" pattern="[0-9]+(\.[0-9][0-9]?)?"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">Amount billed:(Please enter the amount in pounds (and pence  if applicable) without any symbols, do not use commas)</label>
+                                        <@spring.bind "billingDetails.amountBilled" />
+                                        <input type="text" class="form-control" pattern="[0-9]+(\.[0-9][0-9]?)?" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" maxlength="400" id="amountBilled"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">Special arrangements comments:</label>
+                                        <@spring.bind "billingDetails.specialComments" />
+                                        <textarea type="text" class="form-control" name="${spring.status.expression}"
+                                                  value="${spring.status.value!""}" id="comments" rows="4" cols="60" maxlength="400" ><#if billingDetails.getSpecialComments()??>${billingDetails.getSpecialComments()}</#if></textarea>
+                                    </div>
+                                </div>
+
+                                <input type="hidden" id="submitAction" name="action" value="submit"/>
+                                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+                                <input type="hidden" name="vaultID" value="${billingDetails.getVaultID()}"/>
+                                <input type="hidden" name="vaultName" value="${billingDetails.getVaultName()}"/>
+                                <input type="hidden" name="billingType" value="${billingDetails.getBillingType()}"/>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                                    <button type="submit" id="update-billingDetails-btn" class="btn btn-primary btn-ok">Save</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <input type="hidden" name="${_csrf.parameterName}"
+               value="${_csrf.token}" />
+    </div>
+</@layout.vaultLayout>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/billing/billingDetailsNA.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/billing/billingDetailsNA.ftl
@@ -1,0 +1,98 @@
+<#import "*/layout/defaultlayout.ftl" as layout>
+<#global nav="admin">
+<#import "/spring.ftl" as spring />
+<@layout.vaultLayout>
+    <div class="container">
+
+        <ol class="breadcrumb">
+            <li><a
+                        href="${springMacroRequestContext.getContextPath()}/admin/"><b>Administration</b></a></li>
+            <li><a
+                        href="${springMacroRequestContext.getContextPath()}/admin/billing"><b>Billing</b></a></li>
+            <li class="active"><b>BillingDetails:</b>${billingDetails.vaultName?html}</li>
+        </ol>
+        <div class="panel panel-uoe-low">
+            <div class="panel-body">
+                <h2>Billing Details (NA): <small>${billingDetails.vaultName?html}</small></h2>
+
+                <br/>
+                <table class="table table-sm">
+                    <tbody>
+                    <tr>
+                        <th scope="col">Project Id</th>
+                        <td><#if billingDetails.getProjectId()??>${billingDetails.projectId}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Amount to be billed</th>
+                        <td><#if billingDetails.getAmountToBeBilled()??>${billingDetails.getAmountToBeBilled()?html}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Amount billed</th>
+                        <td><#if billingDetails.getAmountBilled()??>${billingDetails.getAmountBilled()?html}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Special arrangement comments</th>
+                        <td><#if billingDetails.getSpecialComments()??>${billingDetails.getSpecialComments()?html}<#else> </#if></td>
+                    </tr>
+                    </tbody>
+                </table>
+
+                <div class="btn-toolbar pull-right">
+                    <button type="button" class="btn btn-default pull-right" data-toggle="modal" data-target="#update-billingDetails">
+                        Edit
+                    </button>
+                </div>
+                <div id="update-billingDetails" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="updateBillingDetails" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <form id="update-billingDetails-form" class="form" role="form" action="${springMacroRequestContext.getContextPath()}/admin/billing/updateBillingDetails" method="post">
+                                <div class="modal-header">
+                                    <h4 class="modal-title" id="addDataManger">Billing Details</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="form-group">
+                                        <label class="control-label">ProjectId:</label>
+                                        <@spring.bind "billingDetails.projectId" />
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="projectId" maxlength="400"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">Amount to be billed:(Please enter the amount in pounds (and pence  if applicable) without any symbols, do not use commas)</label>
+                                        <@spring.bind "billingDetails.amountToBeBilled" />:
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="amountToBeBilled" maxlength="400" pattern="[0-9]+(\.[0-9][0-9]?)?"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">Amount billed:(Please enter the amount in pounds (and pence  if applicable) without any symbols, do not use commas)</label>
+                                        <@spring.bind "billingDetails.amountBilled" />
+                                        <input type="text" class="form-control" pattern="[0-9]+(\.[0-9][0-9]?)?" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" maxlength="400" id="amountBilled"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">Special arrangements comments:</label>
+                                        <@spring.bind "billingDetails.specialComments" />
+                                        <textarea type="text" class="form-control" name="${spring.status.expression}"
+                                                  value="${spring.status.value!""}" id="comments" rows="4" cols="60" maxlength="400" ><#if billingDetails.getSpecialComments()??>${billingDetails.getSpecialComments()}</#if></textarea>
+                                    </div>
+                                </div>
+
+                                <input type="hidden" id="submitAction" name="action" value="submit"/>
+                                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+                                <input type="hidden" name="vaultID" value="${billingDetails.getVaultID()}"/>
+                                <input type="hidden" name="vaultName" value="${billingDetails.getVaultName()}"/>
+                                <input type="hidden" name="billingType" value="${billingDetails.getBillingType()}"/>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                                    <button type="submit" id="update-billingDetails-btn" class="btn btn-primary btn-ok">Save</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <input type="hidden" name="${_csrf.parameterName}"
+               value="${_csrf.token}" />
+    </div>
+</@layout.vaultLayout>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/billing/billingDetailsSlice.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/billing/billingDetailsSlice.ftl
@@ -1,0 +1,108 @@
+<#import "*/layout/defaultlayout.ftl" as layout>
+<#global nav="admin">
+<#import "/spring.ftl" as spring />
+<@layout.vaultLayout>
+    <div class="container">
+
+        <ol class="breadcrumb">
+            <li><a
+                        href="${springMacroRequestContext.getContextPath()}/admin/"><b>Administration</b></a></li>
+            <li><a
+                        href="${springMacroRequestContext.getContextPath()}/admin/billing"><b>Billing</b></a></li>
+            <li class="active"><b>BillingDetails:</b>${billingDetails.vaultName?html}</li>
+        </ol>
+        <div class="panel panel-uoe-low">
+            <div class="panel-body">
+                <h2>Billing Details (Slice): <small>${billingDetails.vaultName?html}</small></h2>
+
+                <br/>
+                <table class="table table-sm">
+                    <tbody>
+                    <tr>
+                        <th scope="col">Slice ID</th>
+                        <td><#if billingDetails.getSliceID()??>${billingDetails.sliceID?html}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Project Id</th>
+                        <td><#if billingDetails.getProjectId()??>${billingDetails.projectId}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Amount to be billed</th>
+                        <td><#if billingDetails.getAmountToBeBilled()??>${billingDetails.getAmountToBeBilled()?html}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Amount billed</th>
+                        <td><#if billingDetails.getAmountBilled()??>${billingDetails.getAmountBilled()?html}<#else> </#if></td>
+                    </tr>
+                    <tr>
+                        <th scope="col">Special arrangement comments</th>
+                        <td><#if billingDetails.getSpecialComments()??>${billingDetails.getSpecialComments()?html}<#else> </#if></td>
+                    </tr>
+                    </tbody>
+                </table>
+
+                <div class="btn-toolbar pull-right">
+                    <button type="button" class="btn btn-default pull-right" data-toggle="modal" data-target="#update-billingDetails">
+                        Edit
+                    </button>
+                </div>
+                <div id="update-billingDetails" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="updateBillingDetails" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <form id="update-billingDetails-form" class="form" role="form" action="${springMacroRequestContext.getContextPath()}/admin/billing/updateBillingDetails" method="post">
+                                <div class="modal-header">
+                                    <h4 class="modal-title" id="addDataManger">Billing Details</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="form-group">
+                                        <label class="control-label">Slice ID:</label>
+                                        <@spring.bind "billingDetails.sliceID" />
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="sliceID" maxlength="40"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">ProjectId:</label>
+                                        <@spring.bind "billingDetails.projectId" />
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="projectId" maxlength="400"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">Amount to be billed:(Please enter the amount in pounds (and pence  if applicable) without any symbols, do not use commas)</label>
+                                        <@spring.bind "billingDetails.amountToBeBilled" />:
+                                        <input type="text" class="form-control" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" id="amountToBeBilled" maxlength="400" pattern="[0-9]+(\.[0-9][0-9]?)?"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">Amount billed:(Please enter the amount in pounds (and pence  if applicable) without any symbols, do not use commas)</label>
+                                        <@spring.bind "billingDetails.amountBilled" />
+                                        <input type="text" class="form-control" pattern="[0-9]+(\.[0-9][0-9]?)?" name="${spring.status.expression}"
+                                               value="${spring.status.value!""}" maxlength="400" id="amountBilled"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label">Special arrangements comments:</label>
+                                        <@spring.bind "billingDetails.specialComments" />
+                                        <textarea type="text" class="form-control" name="${spring.status.expression}"
+                                                  value="${spring.status.value!""}" id="comments" rows="4" cols="60" maxlength="400" ><#if billingDetails.getSpecialComments()??>${billingDetails.getSpecialComments()}</#if></textarea>
+                                    </div>
+                                </div>
+
+                                <input type="hidden" id="submitAction" name="action" value="submit"/>
+                                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+                                <input type="hidden" name="vaultID" value="${billingDetails.getVaultID()}"/>
+                                <input type="hidden" name="vaultName" value="${billingDetails.getVaultName()}"/>
+                                <input type="hidden" name="billingType" value="${billingDetails.getBillingType()}"/>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                                    <button type="submit" id="update-billingDetails-btn" class="btn btn-primary btn-ok">Save</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <input type="hidden" name="${_csrf.parameterName}"
+               value="${_csrf.token}" />
+    </div>
+</@layout.vaultLayout>


### PR DESCRIPTION
A bunch of changes so that 

1) Each of the different billing types can be stored in the billing info table (including the original deprecated type)
2) When a vault is upgraded from a PV to a full vault an entry is made in the billing info table with all the relevant info and the billed totals set to 0
3) The are now different admin/billinginfo pages for each billing type when you click on admin/billing/vault the relevant one is displayed including the original one for vaults created before the metadata changes.
4) The updated functionality on each of these pages has been updated to work (including the original one)
5) When this is deployed there is sql to be run including sql to set the type of the original billing type.

We'll deploy this to demo asap for feedback from the admin users.