### PR TITLE
DS-RSS212-214-2021109 Add estimate review date functionality

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/VaultsController.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/VaultsController.java
@@ -508,10 +508,11 @@ public class VaultsController {
         vault.setContact(createVault.getContactPerson());
         vault.setPureLink(createVault.getPureLink());
 
-        RetentionPolicy retentionPolicy = retentionPoliciesService.getPolicy(createVault.getPolicyID());
+        String policyID = createVault.getPolicyInfo().split("-")[0];
+        RetentionPolicy retentionPolicy = retentionPoliciesService.getPolicy(policyID);
         if (retentionPolicy == null) {
-            logger.error("RetentionPolicy '" + createVault.getPolicyID() + "' does not exist");
-            throw new Exception("RetentionPolicy '" + createVault.getPolicyID() + "' does not exist");
+            logger.error("RetentionPolicy '" + policyID + "' does not exist");
+            throw new Exception("RetentionPolicy '" + policyID + "' does not exist");
         }
         vault.setRetentionPolicy(retentionPolicy);
 
@@ -606,8 +607,14 @@ public class VaultsController {
         vault.setNominatedDataManagers(ndms);
         vault.setDepositors(deps);
         vault.setCreator(creator);
+        logger.debug("Vault Policy ID is '" + vault.getRetentionPolicy().getID());
+        logger.debug("Vault Policy length is '" + vault.getRetentionPolicy().getMinRetentionPeriod());
+
         if (vault != null) {
-            return vault.convertToResponse();
+            VaultInfo retVal = vault.convertToResponse();
+            logger.debug("VaultInfo policy ID is '" + retVal.getPolicyID());
+            logger.debug("VaultInfo policy length is '" + retVal.getPolicyLength());
+            return retVal;
         } else {
             return null;
         }

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/PendingVaultsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/PendingVaultsService.java
@@ -350,7 +350,8 @@ public class PendingVaultsService {
         }
         vault.setUser(user);
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-        String grantEndDate = createVault.getGrantEndDate();
+        String grantEndDate = (createVault.getBillingGrantEndDate() != null &&
+                !createVault.getBillingGrantEndDate().isEmpty()) ? createVault.getBillingGrantEndDate() : createVault.getGrantEndDate();
         if (grantEndDate != null) {
 
             try {

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/PendingVaultsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/PendingVaultsService.java
@@ -267,14 +267,14 @@ public class PendingVaultsService {
             }
         }
 
-        String policyId = createVault.getPolicyID();
+        String policyId = createVault.getPolicyInfo().split("-")[0];
         logger.debug("Retention policy id is: '" + policyId + "'");
         if (policyId != null) {
             RetentionPolicy retentionPolicy = retentionPoliciesService.getPolicy(policyId);
 
             if (retentionPolicy == null) {
-                logger.error("RetentionPolicy '" + createVault.getPolicyID() + "' does not exist");
-                throw new Exception("RetentionPolicy '" + createVault.getPolicyID() + "' does not exist");
+                logger.error("RetentionPolicy '" + policyId + "' does not exist");
+                throw new Exception("RetentionPolicy '" + policyId + "' does not exist");
             }
             vault.setRetentionPolicy(retentionPolicy);
         }

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/VaultsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/VaultsService.java
@@ -6,7 +6,6 @@ import java.util.*;
 import org.datavaultplatform.common.model.*;
 import org.datavaultplatform.common.model.dao.VaultDAO;
 import org.datavaultplatform.common.request.CreateVault;
-import org.datavaultplatform.common.retentionpolicy.RetentionPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/PendingVault.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/PendingVault.java
@@ -361,6 +361,7 @@ public class PendingVault {
         retVal.setAffirmed(this.affirmed);
         if (this.retentionPolicy != null) {
             retVal.setPolicyID(String.valueOf(this.retentionPolicy.getID()));
+            retVal.setPolicyLength(String.valueOf(this.retentionPolicy.getMinRetentionPeriod()));
         }
         retVal.setGrantEndDate(this.grantEndDate);
         if (this.group != null) {

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/RetentionPolicy.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/RetentionPolicy.java
@@ -173,4 +173,10 @@ public class RetentionPolicy {
     public void setDataGuidanceReviewed(Date dataGuidanceReviewed) {
         this.dataGuidanceReviewed = dataGuidanceReviewed;
     }
+
+    public String getPolicyInfo() {
+        String retVal = "";
+        retVal = this.id + "-" + this.minRetentionPeriod;
+        return retVal;
+    }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/Vault.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/Vault.java
@@ -372,6 +372,7 @@ public class Vault {
                 name,
                 description,
                 String.valueOf(retentionPolicy.getID()),
+                String.valueOf(retentionPolicy.getMinRetentionPeriod()),
                 group.getID(),
                 vaultSize,
                 retentionPolicyStatus,

--- a/datavault-common/src/main/java/org/datavaultplatform/common/request/CreateVault.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/request/CreateVault.java
@@ -2,16 +2,11 @@ package org.datavaultplatform.common.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.commons.lang3.StringUtils;
-import org.datavaultplatform.common.model.PendingVault;
 import org.jsondoc.core.annotation.ApiObject;
 import org.jsondoc.core.annotation.ApiObjectField;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @ApiObject(name = "CreateVault")
@@ -38,8 +33,8 @@ public class CreateVault {
     @ApiObjectField(description = "How we are billing")
     private String billingType;
     
-    @ApiObjectField(description = "The policy that will be applied to this vault")
-    private String policyID;
+    @ApiObjectField(description = "The policy that will be applied to this vault the format of the string is policyID-lengthofPolicy")
+    private String policyInfo;
     
     @ApiObjectField(description = "The group which is related to this vault")
     private String groupID;
@@ -172,12 +167,12 @@ public class CreateVault {
         this.billingType = billingType;
     }
 
-    public String getPolicyID() {
-        return policyID;
+    public String getPolicyInfo() {
+        return policyInfo;
     }
 
-    public void setPolicyID(String policyID) {
-        this.policyID = policyID;
+    public void setPolicyInfo(String policyInfo) {
+        this.policyInfo = policyInfo;
     }
 
     public String getGroupID() {

--- a/datavault-common/src/main/java/org/datavaultplatform/common/request/CreateVault.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/request/CreateVault.java
@@ -41,7 +41,10 @@ public class CreateVault {
     
     @ApiObjectField(description = "A reference to an external metadata record that describes this vault")
     private String datasetID;
-    
+
+    @ApiObjectField(description = "Define the minimum of time the archive will be kept")
+    private String billingGrantEndDate;
+
     @ApiObjectField(description = "Define the minimum of time the archive will be kept")
     private String grantEndDate;
     
@@ -197,6 +200,14 @@ public class CreateVault {
 
     public void setGrantEndDate(String grantEndDate) {
         this.grantEndDate = grantEndDate;
+    }
+
+    public String getBillingGrantEndDate() {
+        return billingGrantEndDate;
+    }
+
+    public void setBillingGrantEndDate(String billingGrantEndDate) {
+        this.billingGrantEndDate = billingGrantEndDate;
     }
 
     public String getReviewDate() {

--- a/datavault-common/src/main/java/org/datavaultplatform/common/response/VaultInfo.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/response/VaultInfo.java
@@ -52,6 +52,9 @@ public class VaultInfo {
     
     @ApiObjectField(description = "The policy that applies to this vault")
     private String policyID;
+
+    @ApiObjectField(description = "The length of the policy that applies to this vault")
+    private String policyLength;
     
     @ApiObjectField(description = "The group which is related to this vault")
     private String groupID;
@@ -145,7 +148,7 @@ public class VaultInfo {
     public VaultInfo() { }
 
     public VaultInfo(String id, String userID, String userName, String datasetID, String crisID, String datasetName,
-                     Date creationTime, String name, String description, String policyID, String groupID,
+                     Date creationTime, String name, String description, String policyID, String policyLength, String groupID,
                      long vaultSize, int policyStatus, Date policyExpiry, Date policyLastChecked, Date grantEndDate,
                      Date reviewDate, long numberOfDeposits, String projectId) {
         this.id = id;
@@ -157,6 +160,7 @@ public class VaultInfo {
         this.name = name;
         this.description = description;
         this.policyID = policyID;
+        this.policyLength = policyLength;
         this.groupID = groupID;
         this.vaultSize = vaultSize;
         this.policyStatus = policyStatus;
@@ -284,6 +288,14 @@ public class VaultInfo {
 
     public void setPolicyID(String policyID) {
         this.policyID = policyID;
+    }
+
+    public String getPolicyLength() {
+        return policyLength;
+    }
+
+    public void setPolicyLength(String policyLength) {
+        this.policyLength = policyLength;
     }
 
     public String getGroupID() {
@@ -562,7 +574,7 @@ public class VaultInfo {
         //logger.info("Vault Description is: '" + vault.getDescription());
         cv.setDescription(this.getDescription());
         //logger.info("Create Vault Description is: '" + cv.getDescription());
-        cv.setPolicyID(this.getPolicyID());
+        cv.setPolicyInfo(this.getPolicyID() + "-" + this.getPolicyLength());
         DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd", Locale.UK);
 
         if (this.getGrantEndDate() != null) {

--- a/datavault-common/src/main/java/org/datavaultplatform/common/response/VaultInfo.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/response/VaultInfo.java
@@ -573,6 +573,11 @@ public class VaultInfo {
             cv.setGrantSchoolOrUnit(this.getSchoolOrUnit());
             cv.setGrantSubunit(this.getSubunit());
             cv.setProjectTitle(this.getProjectTitle());
+            DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd", Locale.UK);
+
+            if (this.getGrantEndDate() != null) {
+                cv.setBillingGrantEndDate(formatter.format(this.getGrantEndDate()));
+            }
         }
 
         if (this.getBillingType().equals(PendingVault.Billing_Type.BUDGET_CODE)) {
@@ -593,6 +598,7 @@ public class VaultInfo {
         }
         cv.setGroupID(this.getGroupID());
         if (this.getReviewDate() != null) {
+
             cv.setReviewDate(formatter.format(this.getReviewDate()));
         }
         if (this.getEstimate() != null) {

--- a/datavault-common/src/main/java/org/datavaultplatform/common/response/VaultInfo.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/response/VaultInfo.java
@@ -12,9 +12,7 @@ import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @ApiObject(name = "VaultInfo")
@@ -370,12 +368,30 @@ public class VaultInfo {
         this.grantEndDate = grantEndDate;
     }
 
+    public String getGrantEndDateAsString() {
+        String retVal = "";
+        if (this.getGrantEndDate() != null) {
+            DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+            retVal = formatter.format(this.plusOneDay(this.getGrantEndDate()));
+        }
+        return retVal;
+    }
+
     public Date getReviewDate() {
         return reviewDate;
     }
 
     public void setReviewDate(Date reviewDate) {
         this.reviewDate = reviewDate;
+    }
+
+    public String getReviewDateAsString() {
+        String retVal = "";
+        if (this.getReviewDate() != null) {
+            DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+            retVal = formatter.format(this.plusOneDay(this.getReviewDate()));
+        }
+        return retVal;
     }
 
 	public long getNumberOfDeposits() {
@@ -573,10 +589,9 @@ public class VaultInfo {
             cv.setGrantSchoolOrUnit(this.getSchoolOrUnit());
             cv.setGrantSubunit(this.getSubunit());
             cv.setProjectTitle(this.getProjectTitle());
-            DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd", Locale.UK);
 
             if (this.getGrantEndDate() != null) {
-                cv.setBillingGrantEndDate(formatter.format(this.getGrantEndDate()));
+                cv.setBillingGrantEndDate(this.getGrantEndDateAsString());
             }
         }
 
@@ -587,19 +602,15 @@ public class VaultInfo {
         }
 
         cv.setName(this.getName());
-        //logger.info("Vault Description is: '" + vault.getDescription());
         cv.setDescription(this.getDescription());
-        //logger.info("Create Vault Description is: '" + cv.getDescription());
         cv.setPolicyInfo(this.getPolicyID() + "-" + this.getPolicyLength());
-        DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd", Locale.UK);
 
         if (this.getGrantEndDate() != null) {
-            cv.setGrantEndDate(formatter.format(this.getGrantEndDate()));
+            cv.setGrantEndDate(this.getGrantEndDateAsString());
         }
         cv.setGroupID(this.getGroupID());
         if (this.getReviewDate() != null) {
-
-            cv.setReviewDate(formatter.format(this.getReviewDate()));
+            cv.setReviewDate(this.getReviewDateAsString());
         }
         if (this.getEstimate() != null) {
             cv.setEstimate(this.getEstimate().toString());
@@ -610,10 +621,8 @@ public class VaultInfo {
         // if vault owner is null set isowner to true
         // if vault owner is the same as the logged in user set isowner to true
         // if vault owner is different ot hte logged in user set to false
-        //logger.debug("Setting default isOwner");
         Boolean isOwner = true;
         if (this.getOwnerId() != null && ! this.getOwnerId().equals(this.getUserID())) {
-            //logger.debug("Changing default isOwner");
             isOwner = false;
         }
         cv.setIsOwner(isOwner);
@@ -626,5 +635,18 @@ public class VaultInfo {
         cv.setConfirmed(this.getConfirmed());
 
         return cv;
+    }
+
+    private Date plusOneDay(Date date) {
+        Date retVal = null;
+        if (date != null) {
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(date);
+            cal.add(Calendar.DATE, 1);
+            retVal =  cal.getTime();
+        }
+
+        return retVal;
+
     }
 }

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/VaultsController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/VaultsController.java
@@ -36,7 +36,9 @@ import javax.validation.Valid;
 import javax.validation.constraints.AssertTrue;
 import java.security.Principal;
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -360,9 +362,8 @@ public class VaultsController {
         CreateVault vault = new CreateVault();
         vault.setIsOwner(true);
         model.addAttribute("vault", vault);
-
-        // if it has get that data from the db
-
+        String defaultReviewDate = validateService.getDefaultReviewDate();
+        vault.setReviewDate(defaultReviewDate);
 
         RetentionPolicy[] policies = restService.getRetentionPolicyListing();
         model.addAttribute("policies", policies);

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/VaultsController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/VaultsController.java
@@ -336,7 +336,7 @@ public class VaultsController {
     @RequestMapping(value = "/pendingVaults/{vaultid}", method = RequestMethod.GET)
     public String getPendingVault(ModelMap model, @PathVariable("vaultid") String vaultID, Principal principal) {
         VaultInfo vault = restService.getPendingVault(vaultID);
-
+        logger.info("VI Grant End Date is: ':" + vault.getGrantEndDate() + "'");
         logger.info("Passed in id: '" + vaultID);
 
         if (!canAccessVault(vault, principal)) {
@@ -344,6 +344,7 @@ public class VaultsController {
         }
 
         CreateVault cv = vault.convertToCreate();
+        logger.info("CV Grant End Date is: ':" + cv.getGrantEndDate() + "' - '" + cv.getBillingGrantEndDate() + "'");
         model.addAttribute("vault", cv);
         RetentionPolicy[] policies = restService.getRetentionPolicyListing();
         model.addAttribute("policies", policies);

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/VaultsController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/VaultsController.java
@@ -336,7 +336,6 @@ public class VaultsController {
     @RequestMapping(value = "/pendingVaults/{vaultid}", method = RequestMethod.GET)
     public String getPendingVault(ModelMap model, @PathVariable("vaultid") String vaultID, Principal principal) {
         VaultInfo vault = restService.getPendingVault(vaultID);
-        logger.info("VI Grant End Date is: ':" + vault.getGrantEndDate() + "'");
         logger.info("Passed in id: '" + vaultID);
 
         if (!canAccessVault(vault, principal)) {
@@ -344,7 +343,6 @@ public class VaultsController {
         }
 
         CreateVault cv = vault.convertToCreate();
-        logger.info("CV Grant End Date is: ':" + cv.getGrantEndDate() + "' - '" + cv.getBillingGrantEndDate() + "'");
         model.addAttribute("vault", cv);
         RetentionPolicy[] policies = restService.getRetentionPolicyListing();
         model.addAttribute("policies", policies);

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/ValidateService.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/ValidateService.java
@@ -4,8 +4,8 @@ import org.datavaultplatform.common.request.CreateVault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 public class ValidateService {
     private static final Logger logger = LoggerFactory.getLogger(ValidateService.class);
@@ -173,6 +173,18 @@ public class ValidateService {
         if (pureLink == null || pureLink == false) {
             retVal.add("Pure link not accepted");
         }
+        return retVal;
+    }
+
+    public String getDefaultReviewDate() {
+        String retVal = "";
+        Calendar cal = Calendar.getInstance();
+        cal.setTimeZone(TimeZone.getTimeZone("Europe/London"));
+        cal.add(Calendar.YEAR, 3);
+        Date todayPlus3Years = cal.getTime();
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        retVal = formatter.format(todayPlus3Years);
+
         return retVal;
     }
 }

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/ValidateService.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/ValidateService.java
@@ -138,7 +138,7 @@ public class ValidateService {
             retVal.add("Description missing");
         }
 //        Retention policy
-        String policy = vault.getPolicyID();
+        String policy = vault.getPolicyInfo();
         if (policy == null || policy.isEmpty()) {
             retVal.add("Retention policy missing");
         }

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/ValidateService.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/ValidateService.java
@@ -3,8 +3,11 @@ package org.datavaultplatform.webapp.services;
 import org.datavaultplatform.common.request.CreateVault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.access.method.P;
 
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 public class ValidateService {
@@ -151,6 +154,20 @@ public class ValidateService {
         String reviewDate = vault.getReviewDate();
         if (reviewDate == null || reviewDate.isEmpty()) {
             retVal.add("Review Date missing");
+        } else {
+        // if review date is less than 3 years from today
+            int length = 3;
+            if (policy != null && !policy.isEmpty())  {
+                try {
+                    length = Integer.parseInt(policy.split("-")[1]);
+                } catch (NumberFormatException ne) {
+                    length = 3;
+                }
+            }
+            if (LocalDate.parse(reviewDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+                    .isBefore(LocalDate.parse(this.getDefaultReviewDate(length), DateTimeFormatter.ofPattern("yyyy-MM-dd")))) {
+                retVal.add("Review Date for selected policy is required to be at least " + length + " years");
+            }
         }
 
         return retVal;
@@ -176,15 +193,19 @@ public class ValidateService {
         return retVal;
     }
 
-    public String getDefaultReviewDate() {
+    public String getDefaultReviewDate(int length) {
         String retVal = "";
         Calendar cal = Calendar.getInstance();
         cal.setTimeZone(TimeZone.getTimeZone("Europe/London"));
-        cal.add(Calendar.YEAR, 3);
+        cal.add(Calendar.YEAR, length);
         Date todayPlus3Years = cal.getTime();
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
         retVal = formatter.format(todayPlus3Years);
 
         return retVal;
+    }
+
+    public String getDefaultReviewDate() {
+        return this.getDefaultReviewDate(3);
     }
 }

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/pendingVaults/summary.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/pendingVaults/summary.ftl
@@ -86,8 +86,8 @@
 		<tr>
 			<th scope="col">Grant End Date</th>
 			 <td>
-                <#if (pendingVault.grantEndDate)??>
-                    ${pendingVault.grantEndDate?date}
+                <#if (pendingVault.getGrantEndDate())??>
+                    ${pendingVault.getGrantEndDateAsString()}
                 </#if>
              </td>
 		</tr>
@@ -103,8 +103,8 @@
 		<tr>
 			<th scope="col">Review Date</th>
 			<td>
-              <#if (pendingVault.reviewDate)??>
-                ${pendingVault.reviewDate?date}
+              <#if (pendingVault.getReviewDate())??>
+                ${pendingVault.getReviewDateAsString()}
               </#if>
             </td>
 		</tr>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/billingFieldset.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/billingFieldset.ftl
@@ -79,7 +79,7 @@
                                                  title="This information will assist the university in ensuring the archive is kept for at least the minimum amount of time required by the funder(s). This field should be left blank if there is no grant associated with the work.&nbsp;"></span>
                         </label>
 
-                        <@spring.bind "vault.grantEndDate" />
+                        <@spring.bind "vault.billingGrantEndDate" />
                         <input id="billingGrantEndDate" class="form-control date-picker" placeholder="yyyy-mm-dd" name="${spring.status.expression}"
                                value="${spring.status.value!""}"/>
                     </div>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/index.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/index.ftl
@@ -46,7 +46,7 @@
                                 </td>
                                 <td><#if vault.getOwnerId()??>${vault.getOwnerId()}</#if></td>
                                 <td>${vault.getCreationTime()?datetime}</td>
-                                <td class="text-muted">${vault.getReviewDate()?string('dd/MM/yyyy')}</td>
+                                <td class="text-muted">${vault.getReviewDateAsString()}</td>
                             </tr>
                             </#list>
                         </tbody>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/infoFieldset.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/infoFieldset.ftl
@@ -25,27 +25,6 @@
             <textarea type="text" class="form-control" name="${spring.status.expression}" value="${spring.status.value!""}" id="description" rows="4" cols="60"><#if vault.description??>${vault.description?html}</#if></textarea>
         </div>
 
-        <div class="form-group required">
-            <label for="policyID" class="control-label">Retention Policy</label>
-            <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip"
-                  title="This field indicates the policy with which we must comply, for the purpose of deciding the minimum amount of time for which this dataset &nbsp;must be archived. In most cases this will be the funder's policy. If there are multiple funders, it should be the one with the longest minimum among them.">
-                                                                </span>
-            <a href="https://www.ed.ac.uk/information-services/research-support/research-data-service/planning-your-data/funder-requirements">
-                Read more about retention policies
-            </a>
-            <div class="row">
-                <div class="col-md-12">
-                    <select id="policyID" name="policyID" data-width="auto" class="form-control retentionPolicy-select selectpicker show-tick">
-                        <option selected disabled data-hidden="true">Please choose a retention policy</option>
-                        <#list policies as retentionPolicy>
-                            <option value="${retentionPolicy.getID()}" <#if vault.policyID??>${(vault.policyID == retentionPolicy.getID()?c)?then('selected', 'true')}</#if>
-                                    data-subtext="( Minimum period: ${retentionPolicy.minDataRetentionPeriod?html} )">${retentionPolicy.name?html}</option>
-                        </#list>
-                    </select>
-                </div>
-            </div>
-        </div>
-
         <div class="form-group">
             <label  for="grantEndDate" class="control-label">
                 <strong>Grant End Date</strong>
@@ -64,6 +43,39 @@
                 The Vault will be closed ONE calendar year after the first deposit.
                 Or, if you specify a Grant End Date, ONE calendar year after the Grant End Date IF that falls later than one year after the first deposit.
             </p>
+        </div>
+
+        <div class="form-group required">
+            <label for="policyID" class="control-label">Retention Policy (tell us how long we must keep the data)</label>
+            <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip"
+                  title="Tell us which funder's policy we must comply with. This tells us the minimum amount of time we must keep the data. This information is important when deciding on the Review Date. If there is no funder, choose the University of Edinburgh retention policy. If there are multiple funders, choose the one with the longest minimum retention period. ">
+                                                                </span>
+            <a href="https://www.ed.ac.uk/information-services/research-support/research-data-service/planning-your-data/funder-requirements">
+                Read more about retention policies
+            </a>
+            <div class="row">
+                <div class="col-md-12">
+                    <select id="policyID" name="policyID" data-width="auto" class="form-control retentionPolicy-select selectpicker show-tick">
+                        <option selected disabled data-hidden="true">Please choose a retention policy</option>
+                        <#list policies as retentionPolicy>
+                            <option value="${retentionPolicy.getID()}" <#if vault.policyID??>${(vault.policyID == retentionPolicy.getID()?c)?then('selected', 'true')}</#if>
+                                    data-subtext="( Minimum period: ${retentionPolicy.minDataRetentionPeriod?html} )">${retentionPolicy.name?html}</option>
+                        </#list>
+                    </select>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group required">
+            <label for="reviewDate" class="control-label">
+                <strong>Review Date (tell us how long you want us to keep the data)</strong>
+            </label>
+            <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip"
+                  title="The date by which the vault should be reviewed for decision as to whether it should be deleted or whether there are funds available to support continued storage.&nbsp;If you wish to extend the review date further into the future, please contact the support team to discuss the funding of the storage for the vault.">
+                                                                </span>
+            <@spring.bind "vault.reviewDate" />
+            <input class="form-control" id="reviewDate" placeholder="yyyy-mm-dd" name="${spring.status.expression}"
+                   value="${spring.status.value!""}"/>
         </div>
 
         <div class="form-group required">
@@ -94,18 +106,6 @@
                         </small></small>
                 </div>
             </div>
-        </div>
-
-        <div class="form-group required">
-            <label for="reviewDate" class="control-label">
-                <strong>Review Date (typically ten years from now)</strong>
-            </label>
-            <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip"
-                  title="The date by which the vault should be reviewed for decision as to whether it should be deleted or whether there are funds available to support continued storage.&nbsp;If you wish to extend the review date further into the future, please contact the support team to discuss the funding of the storage for the vault.">
-                                                                </span>
-            <@spring.bind "vault.reviewDate" />
-            <input class="form-control" id="reviewDate" placeholder="yyyy-mm-dd" name="${spring.status.expression}"
-                   value="${spring.status.value!""}"/>
         </div>
 
         <div class="form-group" required>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/infoFieldset.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/infoFieldset.ftl
@@ -58,8 +58,8 @@
                     <select id="policyInfo" name="policyInfo" data-width="auto" class="form-control retentionPolicy-select selectpicker show-tick">
                         <option selected disabled data-hidden="true">Please choose a retention policy</option>
                         <#list policies as retentionPolicy>
-                            <option value="${retentionPolicy.getID()}" <#if vault.policyID??>${(vault.policyID == retentionPolicy.getID()?c)?then('selected', 'true')}</#if>
-                                    data-subtext="(Minimum period: ${retentionPolicy.minRetentionPeriod?html})">${retentionPolicy.name?html}</option>å
+                            <option value="${retentionPolicy.getID()}-${retentionPolicy.minRetentionPeriod}" <#if vault.policyInfo??>${(vault.policyInfo == retentionPolicy.getPolicyInfo())?then('selected', 'true')}</#if>
+                                    data-subtext="( Minimum period: ${retentionPolicy.minRetentionPeriod?html} )">${retentionPolicy.name?html}</option>
                         </#list>
                     </select>
                 </div>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/infoFieldset.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/infoFieldset.ftl
@@ -46,7 +46,7 @@
         </div>
 
         <div class="form-group required">
-            <label for="policyID" class="control-label">Retention Policy (tell us how long we must keep the data)</label>
+            <label for="policyInfo" class="control-label">Retention Policy (tell us how long we must keep the data)</label>
             <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip"
                   title="Tell us which funder's policy we must comply with. This tells us the minimum amount of time we must keep the data. This information is important when deciding on the Review Date. If there is no funder, choose the University of Edinburgh retention policy. If there are multiple funders, choose the one with the longest minimum retention period. ">
                                                                 </span>
@@ -55,11 +55,11 @@
             </a>
             <div class="row">
                 <div class="col-md-12">
-                    <select id="policyID" name="policyID" data-width="auto" class="form-control retentionPolicy-select selectpicker show-tick">
+                    <select id="policyInfo" name="policyInfo" data-width="auto" class="form-control retentionPolicy-select selectpicker show-tick">
                         <option selected disabled data-hidden="true">Please choose a retention policy</option>
                         <#list policies as retentionPolicy>
-                            <option value="${retentionPolicy.getID()}" <#if vault.policyID??>${(vault.policyID == retentionPolicy.getID()?c)?then('selected', 'true')}</#if>
-                                    data-subtext="( Minimum period: ${retentionPolicy.minDataRetentionPeriod?html} )">${retentionPolicy.name?html}</option>
+                            <option value="${retentionPolicy.getID()}-${retentionPolicy.minRetentionPeriod}" <#if vault.policyInfo??>${(vault.policyInfo == retentionPolicy.getPolicyInfo())?then('selected', 'true')}</#if>
+                                    data-subtext="( Minimum period: ${retentionPolicy.minRetentionPeriod?html} )">${retentionPolicy.name?html}</option>
                         </#list>
                     </select>
                 </div>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/newCreatePrototype.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/newCreatePrototype.ftl
@@ -53,6 +53,8 @@
                                                     <input type="hidden" id="submitAction" name="action" value="submit" />
                                                     <@spring.bind "vault.pendingID" />
                                                     <input type="hidden" id="pendingID" name="${spring.status.expression}" value="${spring.status.value!""}" />
+                                                    <@spring.bind "vault.confirmed" />
+                                                    <input type="hidden" id="confirmed" name="${spring.status.expression}" value="${spring.status.value!""}" />
                                                     <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
                                                 </form>
                                             </div>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/vault.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/vault.ftl
@@ -258,7 +258,7 @@
                             </tr>
                             <tr>
                                 <th scope="col">Grant End Date</th>
-                                <td><#if vault.grantEndDate??>${vault.grantEndDate?string('dd/MM/yyyy')}<#else>No end date</#if></td>
+                                <td><#if vault.grantEndDate??>${vault.getGrantEndDateAsString()}<#else>No end date</#if></td>
                                 <td>
                                     <button type="button" class="btn btn-default pull-right" disabled>
                                         Edit review date
@@ -267,7 +267,7 @@
                             </tr>
                             <tr>
                                 <th scope="col">Review Date</th>
-                                <td>${vault.reviewDate?string('dd/MM/yyyy')}</td>
+                                <td>${vault.getReviewDateAsString()}</td>
                                 <td>
                                     <button type="button" class="btn btn-default pull-right" disabled>
                                         Edit review date

--- a/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
+++ b/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
@@ -38,6 +38,74 @@ $(document).ready(function(){
         }
     }).trigger('change');
 
+    $("#billingGrantEndDate, #grantEndDate, #policyID").change(function(){
+        // if the ged changes update the suggested review date
+
+        // if no retention policy picked yet ged + 3 years
+
+        // if a retention policy has been picked ged + policy length
+        var noRP = ($("#policyID option:selected").val() === '' || $("#policyID option:selected").prop("disabled"));
+        var noGED = ($("#grantEndDate").val().trim() === '');
+        var noBillingGED = ($("#billingGrantEndDate").val().trim() === '');
+        var ged = $("#grantEndDate").val().trim();
+        var gedDate = new Date(ged);
+        var gedMm = String(gedDate.getMonth() + 1).padStart(2,'0');
+        var gedDd = String(gedDate.getDate()).padStart(2,'0');
+        var billingGed = $("#billingGrantEndDate").val().trim();
+        var billingGedDate = new Date(billingGed);
+        var billingGedMm = String(billingGedDate.getMonth() + 1).padStart(2,'0');
+        var billingGedDd = String(billingGedDate.getDate()).padStart(2,'0');
+        var defaultLength = 3;
+        // need to get this from the policy somehow!  10 is just a mock value
+        var policyLength = 10;
+        var today = new Date();
+        var dd = String(today.getDate()).padStart(2,'0');
+        var mm = String(today.getMonth() + 1).padStart(2,'0'); // January is 0
+        var yyyy = String(today.getFullYear() + 3);
+
+        var estimatedReviewDate = yyyy + '-' + mm + '-' + dd;
+
+        if (noRP === false && noGED === false) {
+            // if we have both then ged + policy length = review date
+            estimatedReviewDate = String(gedDate.getFullYear() + policyLength) + '-' + gedMm + '-' + gedDd;
+            alert("We have ged and policy change review date to length + ged: '" + estimatedReviewDate + "'");
+        }
+
+        if (noRP === false && noBillingGED === false) {
+            // if we have both then billing ged + policy length = review date
+            estimatedReviewDate = String(billingGedDate.getFullYear() + policyLength) + '-' + billingGedMm + '-' + billingGedDd;
+            alert("We have billing ged and policy change review date to length + ged: '" + estimatedReviewDate + "'");
+        }
+
+        if (noRP === false && noGED === true && noBillingGED === true) {
+            // if we only have policy then length + current date = review date
+            estimatedReviewDate = String(today.getFullYear() + policyLength) + '-' + mm + '-' + dd;
+            alert("We only have the policy change review date to length + current date: '" + estimatedReviewDate + "'");
+        }
+
+        if (noRP === true && noGED === false) {
+            // if we only have ged then ged + 3 = review date
+            estimatedReviewDate = String(gedDate.getFullYear() + defaultLength) + '-' + gedMm + '-' + gedDd;
+            alert("We only have the ged change review date to ged + 3: '" + estimatedReviewDate + "'");
+        }
+
+        if (noRP === true && noBillingGED === false) {
+            // if we only have a ged in the billing fieldset then ged + 3 = review date
+            estimatedReviewDate = String(billingGedDate.getFullYear() + defaultLength) + '-' + billingGedMm + '-' + billingGedDd;
+            alert("We only have the billing ged change review date to ged + 3: '" + estimatedReviewDate + "'");
+        }
+
+        $( "#reviewDate" ).val(estimatedReviewDate);
+    }).trigger('change');
+
+    $("#policyID").change(function(){
+        // if the policy ID changes update the suggested review date
+
+        // if no ged picked yet rt length from todau
+
+        // if a ged has been picked ged + policy length
+    }).trigger('change');
+
     $("#affirmation-check").change(function(){
         $(this).parents("fieldset").children(".next").prop( "disabled", !$(this).is(":checked") );
     }).trigger('change');

--- a/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
+++ b/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
@@ -31,24 +31,12 @@ $(document).ready(function(){
         if (confirmedTrue === false) {
             var dateResult = ($("#billingGrantEndDate").val().trim() === '');
             var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
-            //var noRP = ($("#policyInfo option:selected").val() === '' || $("#policyInfo option:selected").prop("disabled"));
 
             if (dateResult === false && grantChecked === true) {
                 $("#grantEndDate").prop("placeholder", $("#billingGrantEndDate").val());
                 $("#grantEndDate").val($("#billingGrantEndDate").val());
                 $("#grantEndDate").prop("disabled", true);
             } else {
-                /* todo: reset the review date to 3 years from today or the length of the policy is one
-                has been selected
-                */
-                //alert("Reseting Review date");
-                //var length = 3;
-                //var policyInfoString = $("#policyInfo option:selected").val();
-                //var policyInfoArray = policyInfoString.split("-");
-                //if (noRP === false && policyInfoString !== '' && policyInfoArray[1] !== '') {
-                //    alert("Reseting Review date with policy length:" + length);
-                //    length = parseInt(policyInfoArray[1], 10);
-                //}
                 var length = calculateReviewLength();
                 var estimatedReviewDate = calculateReviewDateForToday(length);
 
@@ -381,10 +369,6 @@ $(document).ready(function(){
         $(this).addClass('selected');
     });
 
-    //$(".submit").click(function(){
-    //    return false;
-    //})
-
     $('button[type="submit"]').on("click", function() {
         $('#submitAction').val($(this).attr('value'));
     });
@@ -458,22 +442,12 @@ $(document).ready(function(){
             // enable or disable the grant end date field on the info fieldset
             var dateResult = ($("#billingGrantEndDate").val().trim() === '');
             var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
-            //var noRP = ($("#policyInfo option:selected").val() === '' || $("#policyInfo option:selected").prop("disabled"));
 
             if (dateResult === false && grantChecked === true) {
                 $("#grantEndDate").prop("placeholder", $("#billingGrantEndDate").val());
                 $("#grantEndDate").val($("#billingGrantEndDate").val());
                 $("#grantEndDate").prop("disabled", true);
             } else {
-                //alert("Reseting Review date");
-                //var length = 3;
-                //var policyInfoString = $("#policyInfo option:selected").val();
-                //var policyInfoArray = policyInfoString.split("-");
-                // need to get this from the policy somehow!  10 is just a mock value
-                //if (noRP === false && policyInfoString !== '' && policyInfoArray[1] !== '') {
-                //    length = parseInt(policyInfoArray[1], 10);
-                //    alert("Reseting Review date with policy length:" + length);
-                //}
                 var length = calculateReviewLength();
                 var estimatedReviewDate = calculateReviewDateForToday(length);
                 $("#grantEndDate").prop("disabled", false);

--- a/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
+++ b/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
@@ -31,22 +31,29 @@ $(document).ready(function(){
         if (confirmedTrue === false) {
             var dateResult = ($("#billingGrantEndDate").val().trim() === '');
             var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
+            //var noRP = ($("#policyInfo option:selected").val() === '' || $("#policyInfo option:selected").prop("disabled"));
 
             if (dateResult === false && grantChecked === true) {
-                // disable false now so any updates will be picked up (even if currently disabled)
-                //$("#grantEndDate").prop("disabled", false);
                 $("#grantEndDate").prop("placeholder", $("#billingGrantEndDate").val());
                 $("#grantEndDate").val($("#billingGrantEndDate").val());
-                // disable or disable again if it was already disabled before these changes
                 $("#grantEndDate").prop("disabled", true);
             } else {
                 /* todo: reset the review date to 3 years from today or the length of the policy is one
                 has been selected
                 */
-                var estimatedReviewDate = calculateReviewDateForToday();
+                //alert("Reseting Review date");
+                //var length = 3;
+                //var policyInfoString = $("#policyInfo option:selected").val();
+                //var policyInfoArray = policyInfoString.split("-");
+                //if (noRP === false && policyInfoString !== '' && policyInfoArray[1] !== '') {
+                //    alert("Reseting Review date with policy length:" + length);
+                //    length = parseInt(policyInfoArray[1], 10);
+                //}
+                var length = calculateReviewLength();
+                var estimatedReviewDate = calculateReviewDateForToday(length);
 
                 $("#grantEndDate").prop("disabled", false);
-                $("#grantEndDate").text("");
+                $("#grantEndDate").val("");
                 $("#grantEndDate").prop("placeholder", "yyyy-mm-dd");
                 $("#reviewDate").val(estimatedReviewDate);
             }
@@ -86,7 +93,7 @@ $(document).ready(function(){
             //var yyyy = String(today.getFullYear() + 3);
 
             //var estimatedReviewDate = yyyy + '-' + mm + '-' + dd;
-            var estimatedReviewDate = calculateReviewDateForToday();
+            var estimatedReviewDate = calculateReviewDateForToday(defaultLength);
 
             if (noRP === false && noGED === false) {
                 // if we have both then ged + policy length = review date
@@ -451,13 +458,24 @@ $(document).ready(function(){
             // enable or disable the grant end date field on the info fieldset
             var dateResult = ($("#billingGrantEndDate").val().trim() === '');
             var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
+            //var noRP = ($("#policyInfo option:selected").val() === '' || $("#policyInfo option:selected").prop("disabled"));
 
             if (dateResult === false && grantChecked === true) {
                 $("#grantEndDate").prop("placeholder", $("#billingGrantEndDate").val());
                 $("#grantEndDate").val($("#billingGrantEndDate").val());
                 $("#grantEndDate").prop("disabled", true);
             } else {
-                var estimatedReviewDate = calculateReviewDateForToday();
+                //alert("Reseting Review date");
+                //var length = 3;
+                //var policyInfoString = $("#policyInfo option:selected").val();
+                //var policyInfoArray = policyInfoString.split("-");
+                // need to get this from the policy somehow!  10 is just a mock value
+                //if (noRP === false && policyInfoString !== '' && policyInfoArray[1] !== '') {
+                //    length = parseInt(policyInfoArray[1], 10);
+                //    alert("Reseting Review date with policy length:" + length);
+                //}
+                var length = calculateReviewLength();
+                var estimatedReviewDate = calculateReviewDateForToday(length);
                 $("#grantEndDate").prop("disabled", false);
                 $("#grantEndDate").val("");
                 $("#grantEndDate").prop("placeholder", "yyyy-mm-dd");
@@ -594,16 +612,26 @@ $(document).ready(function(){
     	
     }
 
-    function calculateReviewDateForToday() {
+    function calculateReviewDateForToday(length) {
         var today = new Date();
         var dd = String(today.getDate()).padStart(2,'0');
         var mm = String(today.getMonth() + 1).padStart(2,'0'); // January is 0
-        // do we have a retention policy
-        // if yes use it's length if not use the default
-        var defaultLength = 3;
-        var length = defaultLength;
-        var yyyy = String(today.getFullYear() + length);
+        var yyyy = String(today.getFullYear() + parseInt(length, 10));
 
         return yyyy + '-' + mm + '-' + dd;
+    }
+
+    function calculateReviewLength() {
+        var noRP = ($("#policyInfo option:selected").val() === '' || $("#policyInfo option:selected").prop("disabled"));
+
+        var length = 3;
+        var policyInfoString = $("#policyInfo option:selected").val();
+        var policyInfoArray = policyInfoString.split("-");
+
+        if (noRP === false && policyInfoString !== '' && policyInfoArray[1] !== '') {
+            length = parseInt(policyInfoArray[1], 10);
+        }
+
+        return length
     }
 });

--- a/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
+++ b/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
@@ -22,19 +22,38 @@ $(document).ready(function(){
         minDate: '+1m'
     });
 
-    // if billingtype changes blank all billing fields (remember to fix date on info page)
+    /*
+    if billinGrantEndDate is filled in, disable granteddate on the info page and populate it with the billing value
+    if billingGrantEndDate is cleared enable grantenddate on the info page and populate it with placeholder also reset review date
+     */
     $( "#billingGrantEndDate" ).change(function() {
-        // :todo make sure info version of field is only disabled if the billing one has a valid value
+        alert("Enabling / disabling grantEndDate");
         var dateResult = ($(this).val().trim() === '');
         var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
 
         if (dateResult === false && grantChecked === true) {
+            // disable false now so any updates will be picked up (even if currently disabled)
+            $("#grantEndDate").prop("disabled", false);
             $("#grantEndDate").prop("placeholder", $(this).val());
             $("#grantEndDate").text($(this).val());
+            // disalbe or disable again if it was already disabled before these changes
             $("#grantEndDate").prop("disabled", true);
         } else {
+            /* todo: reset the review date to 3 years from today or the length of the policy is one
+            has been selected
+             */
+            /*
+            var today = new Date();
+            var dd = String(today.getDate()).padStart(2,'0');
+            var mm = String(today.getMonth() + 1).padStart(2,'0'); // January is 0
+            var yyyy = String(today.getFullYear() + 3);
+
+            var estimatedReviewDate = yyyy + '-' + mm + '-' + dd;*/
+
             $("#grantEndDate").prop("disabled", false);
+            $("#grantEndDate").text("");
             $("#grantEndDate").prop("placeholder", "yyyy-mm-dd");
+            /*$("reviewDate").val(estimatedReviewDate);*/
         }
     }).trigger('change');
 

--- a/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
+++ b/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
@@ -27,33 +27,26 @@ $(document).ready(function(){
     if billingGrantEndDate is cleared enable grantenddate on the info page and populate it with placeholder also reset review date
      */
     $( "#billingGrantEndDate" ).change(function() {
-        alert("Enabling / disabling grantEndDate");
-        var dateResult = ($(this).val().trim() === '');
+        var dateResult = ($("#billingGrantEndDate").val().trim() === '');
         var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
 
         if (dateResult === false && grantChecked === true) {
             // disable false now so any updates will be picked up (even if currently disabled)
-            $("#grantEndDate").prop("disabled", false);
-            $("#grantEndDate").prop("placeholder", $(this).val());
-            $("#grantEndDate").text($(this).val());
-            // disalbe or disable again if it was already disabled before these changes
+            //$("#grantEndDate").prop("disabled", false);
+            $("#grantEndDate").prop("placeholder", $("#billingGrantEndDate").val());
+            $("#grantEndDate").val($("#billingGrantEndDate").val());
+            // disable or disable again if it was already disabled before these changes
             $("#grantEndDate").prop("disabled", true);
         } else {
             /* todo: reset the review date to 3 years from today or the length of the policy is one
             has been selected
-             */
-            /*
-            var today = new Date();
-            var dd = String(today.getDate()).padStart(2,'0');
-            var mm = String(today.getMonth() + 1).padStart(2,'0'); // January is 0
-            var yyyy = String(today.getFullYear() + 3);
-
-            var estimatedReviewDate = yyyy + '-' + mm + '-' + dd;*/
+            */
+            var estimatedReviewDate = calculateReviewDateForToday();
 
             $("#grantEndDate").prop("disabled", false);
             $("#grantEndDate").text("");
             $("#grantEndDate").prop("placeholder", "yyyy-mm-dd");
-            /*$("reviewDate").val(estimatedReviewDate);*/
+            $("#reviewDate").val(estimatedReviewDate);
         }
     }).trigger('change');
 
@@ -86,9 +79,10 @@ $(document).ready(function(){
         var today = new Date();
         var dd = String(today.getDate()).padStart(2,'0');
         var mm = String(today.getMonth() + 1).padStart(2,'0'); // January is 0
-        var yyyy = String(today.getFullYear() + 3);
+        //var yyyy = String(today.getFullYear() + 3);
 
-        var estimatedReviewDate = yyyy + '-' + mm + '-' + dd;
+        //var estimatedReviewDate = yyyy + '-' + mm + '-' + dd;
+        var estimatedReviewDate = calculateReviewDateForToday();
 
         if (noRP === false && noGED === false) {
             // if we have both then ged + policy length = review date
@@ -454,11 +448,14 @@ $(document).ready(function(){
 
         if (dateResult === false && grantChecked === true) {
             $("#grantEndDate").prop("placeholder", $("#billingGrantEndDate").val());
-            $("#grantEndDate").text($("#billingGrantEndDate").val());
+            $("#grantEndDate").val($("#billingGrantEndDate").val());
             $("#grantEndDate").prop("disabled", true);
         } else {
+            var estimatedReviewDate = calculateReviewDateForToday();
             $("#grantEndDate").prop("disabled", false);
+            $("#grantEndDate").val("");
             $("#grantEndDate").prop("placeholder", "yyyy-mm-dd");
+            $("#reviewDate").val(estimatedReviewDate);
         }
 
         // clear the unused fieldsets
@@ -588,5 +585,18 @@ $(document).ready(function(){
     		return html;
     	}
     	
+    }
+
+    function calculateReviewDateForToday() {
+        var today = new Date();
+        var dd = String(today.getDate()).padStart(2,'0');
+        var mm = String(today.getMonth() + 1).padStart(2,'0'); // January is 0
+        // do we have a retention policy
+        // if yes use it's length if not use the default
+        var defaultLength = 3;
+        var length = defaultLength;
+        var yyyy = String(today.getFullYear() + length);
+
+        return yyyy + '-' + mm + '-' + dd;
     }
 });

--- a/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
+++ b/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
@@ -2,6 +2,7 @@
 $(document).ready(function(){
     var current_fs, next_fs, previous_fs;
     var opacity;
+    var confirmedTrue = ($("#confirmed").val() === 'true');
     
     // Prevent Enter Key Submitting Form
     $("form input").on("keypress", function(e) {
@@ -27,26 +28,28 @@ $(document).ready(function(){
     if billingGrantEndDate is cleared enable grantenddate on the info page and populate it with placeholder also reset review date
      */
     $( "#billingGrantEndDate" ).change(function() {
-        var dateResult = ($("#billingGrantEndDate").val().trim() === '');
-        var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
+        if (confirmedTrue === false) {
+            var dateResult = ($("#billingGrantEndDate").val().trim() === '');
+            var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
 
-        if (dateResult === false && grantChecked === true) {
-            // disable false now so any updates will be picked up (even if currently disabled)
-            //$("#grantEndDate").prop("disabled", false);
-            $("#grantEndDate").prop("placeholder", $("#billingGrantEndDate").val());
-            $("#grantEndDate").val($("#billingGrantEndDate").val());
-            // disable or disable again if it was already disabled before these changes
-            $("#grantEndDate").prop("disabled", true);
-        } else {
-            /* todo: reset the review date to 3 years from today or the length of the policy is one
-            has been selected
-            */
-            var estimatedReviewDate = calculateReviewDateForToday();
+            if (dateResult === false && grantChecked === true) {
+                // disable false now so any updates will be picked up (even if currently disabled)
+                //$("#grantEndDate").prop("disabled", false);
+                $("#grantEndDate").prop("placeholder", $("#billingGrantEndDate").val());
+                $("#grantEndDate").val($("#billingGrantEndDate").val());
+                // disable or disable again if it was already disabled before these changes
+                $("#grantEndDate").prop("disabled", true);
+            } else {
+                /* todo: reset the review date to 3 years from today or the length of the policy is one
+                has been selected
+                */
+                var estimatedReviewDate = calculateReviewDateForToday();
 
-            $("#grantEndDate").prop("disabled", false);
-            $("#grantEndDate").text("");
-            $("#grantEndDate").prop("placeholder", "yyyy-mm-dd");
-            $("#reviewDate").val(estimatedReviewDate);
+                $("#grantEndDate").prop("disabled", false);
+                $("#grantEndDate").text("");
+                $("#grantEndDate").prop("placeholder", "yyyy-mm-dd");
+                $("#reviewDate").val(estimatedReviewDate);
+            }
         }
     }).trigger('change');
 
@@ -56,60 +59,62 @@ $(document).ready(function(){
         // if no retention policy picked yet ged + 3 years
 
         // if a retention policy has been picked ged + policy length
-        var noRP = ($("#policyInfo option:selected").val() === '' || $("#policyInfo option:selected").prop("disabled"));
-        var noGED = ($("#grantEndDate").val().trim() === '');
-        var noBillingGED = ($("#billingGrantEndDate").val().trim() === '');
-        var ged = $("#grantEndDate").val().trim();
-        var gedDate = new Date(ged);
-        var gedMm = String(gedDate.getMonth() + 1).padStart(2,'0');
-        var gedDd = String(gedDate.getDate()).padStart(2,'0');
-        var billingGed = $("#billingGrantEndDate").val().trim();
-        var billingGedDate = new Date(billingGed);
-        var billingGedMm = String(billingGedDate.getMonth() + 1).padStart(2,'0');
-        var billingGedDd = String(billingGedDate.getDate()).padStart(2,'0');
-        var defaultLength = 3;
-        var policyInfoString = $("#policyInfo option:selected").val();
-        //alert("policy info string:'" + policyInfoString + "'");
-        var policyInfoArray = policyInfoString.split("-");
-        // need to get this from the policy somehow!  10 is just a mock value
-        var policyLength = defaultLength;
-        if (noRP === false && policyInfoString !== '' && policyInfoArray[1] !== '') {
-            policyLength = parseInt(policyInfoArray[1], 10);
+        if (confirmedTrue === false) {
+            var noRP = ($("#policyInfo option:selected").val() === '' || $("#policyInfo option:selected").prop("disabled"));
+            var noGED = ($("#grantEndDate").val().trim() === '');
+            var noBillingGED = ($("#billingGrantEndDate").val().trim() === '');
+            var ged = $("#grantEndDate").val().trim();
+            var gedDate = new Date(ged);
+            var gedMm = String(gedDate.getMonth() + 1).padStart(2, '0');
+            var gedDd = String(gedDate.getDate()).padStart(2, '0');
+            var billingGed = $("#billingGrantEndDate").val().trim();
+            var billingGedDate = new Date(billingGed);
+            var billingGedMm = String(billingGedDate.getMonth() + 1).padStart(2, '0');
+            var billingGedDd = String(billingGedDate.getDate()).padStart(2, '0');
+            var defaultLength = 3;
+            var policyInfoString = $("#policyInfo option:selected").val();
+            //alert("policy info string:'" + policyInfoString + "'");
+            var policyInfoArray = policyInfoString.split("-");
+            // need to get this from the policy somehow!  10 is just a mock value
+            var policyLength = defaultLength;
+            if (noRP === false && policyInfoString !== '' && policyInfoArray[1] !== '') {
+                policyLength = parseInt(policyInfoArray[1], 10);
+            }
+            var today = new Date();
+            var dd = String(today.getDate()).padStart(2, '0');
+            var mm = String(today.getMonth() + 1).padStart(2, '0'); // January is 0
+            //var yyyy = String(today.getFullYear() + 3);
+
+            //var estimatedReviewDate = yyyy + '-' + mm + '-' + dd;
+            var estimatedReviewDate = calculateReviewDateForToday();
+
+            if (noRP === false && noGED === false) {
+                // if we have both then ged + policy length = review date
+                estimatedReviewDate = String(gedDate.getFullYear() + policyLength) + '-' + gedMm + '-' + gedDd;
+            }
+
+            if (noRP === false && noBillingGED === false) {
+                // if we have both then billing ged + policy length = review date
+                estimatedReviewDate = String(billingGedDate.getFullYear() + policyLength) + '-' + billingGedMm + '-' + billingGedDd;
+            }
+
+            if (noRP === false && noGED === true && noBillingGED === true) {
+                // if we only have policy then length + current date = review date
+                estimatedReviewDate = String(today.getFullYear() + policyLength) + '-' + mm + '-' + dd;
+            }
+
+            if (noRP === true && noGED === false) {
+                // if we only have ged then ged + 3 = review date
+                estimatedReviewDate = String(gedDate.getFullYear() + defaultLength) + '-' + gedMm + '-' + gedDd;
+            }
+
+            if (noRP === true && noBillingGED === false) {
+                // if we only have a ged in the billing fieldset then ged + 3 = review date
+                estimatedReviewDate = String(billingGedDate.getFullYear() + defaultLength) + '-' + billingGedMm + '-' + billingGedDd;
+            }
+
+            $("#reviewDate").val(estimatedReviewDate);
         }
-        var today = new Date();
-        var dd = String(today.getDate()).padStart(2,'0');
-        var mm = String(today.getMonth() + 1).padStart(2,'0'); // January is 0
-        //var yyyy = String(today.getFullYear() + 3);
-
-        //var estimatedReviewDate = yyyy + '-' + mm + '-' + dd;
-        var estimatedReviewDate = calculateReviewDateForToday();
-
-        if (noRP === false && noGED === false) {
-            // if we have both then ged + policy length = review date
-            estimatedReviewDate = String(gedDate.getFullYear() + policyLength) + '-' + gedMm + '-' + gedDd;
-        }
-
-        if (noRP === false && noBillingGED === false) {
-            // if we have both then billing ged + policy length = review date
-            estimatedReviewDate = String(billingGedDate.getFullYear() + policyLength) + '-' + billingGedMm + '-' + billingGedDd;
-        }
-
-        if (noRP === false && noGED === true && noBillingGED === true) {
-            // if we only have policy then length + current date = review date
-            estimatedReviewDate = String(today.getFullYear() + policyLength) + '-' + mm + '-' + dd;
-        }
-
-        if (noRP === true && noGED === false) {
-            // if we only have ged then ged + 3 = review date
-            estimatedReviewDate = String(gedDate.getFullYear() + defaultLength) + '-' + gedMm + '-' + gedDd;
-        }
-
-        if (noRP === true && noBillingGED === false) {
-            // if we only have a ged in the billing fieldset then ged + 3 = review date
-            estimatedReviewDate = String(billingGedDate.getFullYear() + defaultLength) + '-' + billingGedMm + '-' + billingGedDd;
-        }
-
-        $( "#reviewDate" ).val(estimatedReviewDate);
     }).trigger('change');
 
     $("#affirmation-check").change(function(){
@@ -442,46 +447,48 @@ $(document).ready(function(){
    }
     
     function clearBillingOptions() {
-        // enable or disable the grant end date field on the info fieldset
-        var dateResult = ($("#billingGrantEndDate").val().trim() === '');
-        var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
+        if (confirmedTrue === false) {
+            // enable or disable the grant end date field on the info fieldset
+            var dateResult = ($("#billingGrantEndDate").val().trim() === '');
+            var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
 
-        if (dateResult === false && grantChecked === true) {
-            $("#grantEndDate").prop("placeholder", $("#billingGrantEndDate").val());
-            $("#grantEndDate").val($("#billingGrantEndDate").val());
-            $("#grantEndDate").prop("disabled", true);
-        } else {
-            var estimatedReviewDate = calculateReviewDateForToday();
-            $("#grantEndDate").prop("disabled", false);
-            $("#grantEndDate").val("");
-            $("#grantEndDate").prop("placeholder", "yyyy-mm-dd");
-            $("#reviewDate").val(estimatedReviewDate);
-        }
+            if (dateResult === false && grantChecked === true) {
+                $("#grantEndDate").prop("placeholder", $("#billingGrantEndDate").val());
+                $("#grantEndDate").val($("#billingGrantEndDate").val());
+                $("#grantEndDate").prop("disabled", true);
+            } else {
+                var estimatedReviewDate = calculateReviewDateForToday();
+                $("#grantEndDate").prop("disabled", false);
+                $("#grantEndDate").val("");
+                $("#grantEndDate").prop("placeholder", "yyyy-mm-dd");
+                $("#reviewDate").val(estimatedReviewDate);
+            }
 
-        // clear the unused fieldsets
-        var naChecked = ($("#billing-choice-na").is(":checked"));
-        var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
-        var budgetChecked = ($("#billing-choice-budgetcode").is(":checked"));
-        var sliceChecked = ($("#billing-choice-slice").is(":checked"));
-        // if billing type is not grant clear fieldset
-        if (naChecked === true) {
-            $("#grant-billing-form input").val("");
-            $("#budget-billing-form input").val("");
-            $("#slice-form input").val("");
-        }
-        if (grantChecked === true) {
-            $("#budget-billing-form input").val("");
-            $("#slice-form input").val("");
-        }
+            // clear the unused fieldsets
+            var naChecked = ($("#billing-choice-na").is(":checked"));
+            var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
+            var budgetChecked = ($("#billing-choice-budgetcode").is(":checked"));
+            var sliceChecked = ($("#billing-choice-slice").is(":checked"));
+            // if billing type is not grant clear fieldset
+            if (naChecked === true) {
+                $("#grant-billing-form input").val("");
+                $("#budget-billing-form input").val("");
+                $("#slice-form input").val("");
+            }
+            if (grantChecked === true) {
+                $("#budget-billing-form input").val("");
+                $("#slice-form input").val("");
+            }
 
-        if (budgetChecked === true) {
-            $("#grant-billing-form input").val("");
-            $("#slice-form input").val("");
-        }
+            if (budgetChecked === true) {
+                $("#grant-billing-form input").val("");
+                $("#slice-form input").val("");
+            }
 
-        if (sliceChecked === true) {
-            $("#grant-billing-form input").val("");
-            $("#budget-billing-form input").val("");
+            if (sliceChecked === true) {
+                $("#grant-billing-form input").val("");
+                $("#budget-billing-form input").val("");
+            }
         }
     }
 

--- a/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
+++ b/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
@@ -38,13 +38,13 @@ $(document).ready(function(){
         }
     }).trigger('change');
 
-    $("#billingGrantEndDate, #grantEndDate, #policyID").change(function(){
+    $("#billingGrantEndDate, #grantEndDate, #policyInfo").change(function(){
         // if the ged changes update the suggested review date
 
         // if no retention policy picked yet ged + 3 years
 
         // if a retention policy has been picked ged + policy length
-        var noRP = ($("#policyID option:selected").val() === '' || $("#policyID option:selected").prop("disabled"));
+        var noRP = ($("#policyInfo option:selected").val() === '' || $("#policyInfo option:selected").prop("disabled"));
         var noGED = ($("#grantEndDate").val().trim() === '');
         var noBillingGED = ($("#billingGrantEndDate").val().trim() === '');
         var ged = $("#grantEndDate").val().trim();
@@ -56,8 +56,14 @@ $(document).ready(function(){
         var billingGedMm = String(billingGedDate.getMonth() + 1).padStart(2,'0');
         var billingGedDd = String(billingGedDate.getDate()).padStart(2,'0');
         var defaultLength = 3;
+        var policyInfoString = $("#policyInfo option:selected").val();
+        //alert("policy info string:'" + policyInfoString + "'");
+        var policyInfoArray = policyInfoString.split("-");
         // need to get this from the policy somehow!  10 is just a mock value
-        var policyLength = 10;
+        var policyLength = defaultLength;
+        if (noRP === false && policyInfoString !== '' && policyInfoArray[1] !== '') {
+            policyLength = parseInt(policyInfoArray[1], 10);
+        }
         var today = new Date();
         var dd = String(today.getDate()).padStart(2,'0');
         var mm = String(today.getMonth() + 1).padStart(2,'0'); // January is 0
@@ -68,19 +74,19 @@ $(document).ready(function(){
         if (noRP === false && noGED === false) {
             // if we have both then ged + policy length = review date
             estimatedReviewDate = String(gedDate.getFullYear() + policyLength) + '-' + gedMm + '-' + gedDd;
-            alert("We have ged and policy change review date to length + ged: '" + estimatedReviewDate + "'");
+            alert("We have ged and policy change review date to length for '" + policyLength + "' ged: '" + estimatedReviewDate + "'");
         }
 
         if (noRP === false && noBillingGED === false) {
             // if we have both then billing ged + policy length = review date
             estimatedReviewDate = String(billingGedDate.getFullYear() + policyLength) + '-' + billingGedMm + '-' + billingGedDd;
-            alert("We have billing ged and policy change review date to length + ged: '" + estimatedReviewDate + "'");
+            alert("We have billing ged and policy change review date to length for '" + policyLength + "'ged: '" + estimatedReviewDate + "'");
         }
 
         if (noRP === false && noGED === true && noBillingGED === true) {
             // if we only have policy then length + current date = review date
             estimatedReviewDate = String(today.getFullYear() + policyLength) + '-' + mm + '-' + dd;
-            alert("We only have the policy change review date to length + current date: '" + estimatedReviewDate + "'");
+            alert("We only have the policy '" + policyLength + "' change review date to length + current date: '" + estimatedReviewDate + "'");
         }
 
         if (noRP === true && noGED === false) {
@@ -98,19 +104,11 @@ $(document).ready(function(){
         $( "#reviewDate" ).val(estimatedReviewDate);
     }).trigger('change');
 
-    $("#policyID").change(function(){
-        // if the policy ID changes update the suggested review date
-
-        // if no ged picked yet rt length from todau
-
-        // if a ged has been picked ged + policy length
-    }).trigger('change');
-
     $("#affirmation-check").change(function(){
         $(this).parents("fieldset").children(".next").prop( "disabled", !$(this).is(":checked") );
     }).trigger('change');
 
-    $("#vaultName, #description, #policyID, #groupID, #reviewDate").change(function(){
+    $("#vaultName, #description, #policyInfo, #groupID, #reviewDate").change(function(){
         // if all the mandatory values in the info field set are non null or empty set the next button
         // display value to true
         // name
@@ -118,7 +116,7 @@ $(document).ready(function(){
         // description
         var descResult = ($( "textarea[type=text][id=description]").val() === '');
         // retention policy
-        var rpResult = ($("#policyID option:selected").val() === '' || $("#policyID option:selected").prop("disabled"));
+        var rpResult = ($("#policyInfo option:selected").val() === '' || $("#policyInfo option:selected").prop("disabled"));
         // school
         var schoolResult = ($("#groupID option:selected").val() === '' || $("#groupID option:selected").prop("disabled"));
         // review date
@@ -488,7 +486,7 @@ $(document).ready(function(){
     	  // VaultInfo
     	  $("#summary-vaultName").text($("#vaultName").val());
     	  $("#summary-description").text($("#description").val());
-    	  $("#summary-policyID").text($("#policyID option:selected").text());
+    	  $("#summary-policyID").text($("#policyInfo option:selected").text());
     	  var grantChecked = ($("#billing-choice-grantfunding").is(":checked"));
     	  if (grantChecked === true) {
               $("#summary-grantEndDate").text($("#billingGrantEndDate").val());

--- a/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
+++ b/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
@@ -74,31 +74,26 @@ $(document).ready(function(){
         if (noRP === false && noGED === false) {
             // if we have both then ged + policy length = review date
             estimatedReviewDate = String(gedDate.getFullYear() + policyLength) + '-' + gedMm + '-' + gedDd;
-            alert("We have ged and policy change review date to length for '" + policyLength + "' ged: '" + estimatedReviewDate + "'");
         }
 
         if (noRP === false && noBillingGED === false) {
             // if we have both then billing ged + policy length = review date
             estimatedReviewDate = String(billingGedDate.getFullYear() + policyLength) + '-' + billingGedMm + '-' + billingGedDd;
-            alert("We have billing ged and policy change review date to length for '" + policyLength + "'ged: '" + estimatedReviewDate + "'");
         }
 
         if (noRP === false && noGED === true && noBillingGED === true) {
             // if we only have policy then length + current date = review date
             estimatedReviewDate = String(today.getFullYear() + policyLength) + '-' + mm + '-' + dd;
-            alert("We only have the policy '" + policyLength + "' change review date to length + current date: '" + estimatedReviewDate + "'");
         }
 
         if (noRP === true && noGED === false) {
             // if we only have ged then ged + 3 = review date
             estimatedReviewDate = String(gedDate.getFullYear() + defaultLength) + '-' + gedMm + '-' + gedDd;
-            alert("We only have the ged change review date to ged + 3: '" + estimatedReviewDate + "'");
         }
 
         if (noRP === true && noBillingGED === false) {
             // if we only have a ged in the billing fieldset then ged + 3 = review date
             estimatedReviewDate = String(billingGedDate.getFullYear() + defaultLength) + '-' + billingGedMm + '-' + billingGedDd;
-            alert("We only have the billing ged change review date to ged + 3: '" + estimatedReviewDate + "'");
         }
 
         $( "#reviewDate" ).val(estimatedReviewDate);


### PR DESCRIPTION
This adds functionality to estimate review date value for the user when setting up a vault, it initially suggest 3 years from today but as the GED and retention policy are selected / deselected / changed it will continue to re estimate.

There is also some server side validation that stops the creation of the pending vault if the review is before the minimum length of the selected policy.

There is a separate ticket to add client side validation for this.

This PR also contains a fix for RSS212-223 (as it was easier to do on this code) and various other fixes (the GED being misformatted on various pages which resulted in it being displayed as a day earlier)