### PR TITLE
RSS212-195: Fix for "Accessibility problem with green-on-grey progres…

### DIFF
--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/deposit.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/deposits/deposit.ftl
@@ -27,7 +27,9 @@
             <div id="progress-transfer" style="display:none;">
                 <span id="progress-copied">Placeholder</span>
                 <div class="progress">
-                  <div id="progress" class="progress-bar progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%">
+                  <div id="progress" class="progress-bar progress-bar-striped active" 
+                  role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" 
+                  aria-valuetext="0% Complete">
                     <span id="progress-label" class="sr-only">0% Complete</span>
                   </div>
                 </div>
@@ -241,6 +243,7 @@
             }
             
             $('#progress').css('width', percentComplete + '%').attr('aria-valuenow', percentComplete);
+            $('#progress').attr('aria-valuetext', percentComplete + '% Complete');
             $('#progress-label').text(percentComplete + '% Complete')
             $('#progress-copied').text(job.progressMessage)
         }
@@ -331,6 +334,15 @@
 </script>
 
 <style>
+    /** Overrides color of progress bar */
+    ol.progtrckr li.progtrckr-done {
+      border-bottom: 4px solid #046B99;
+    }
+    
+    ol.progtrckr li.progtrckr-done:before {
+      background-color: #046B99;
+    }
+    
     .glyphicon-refresh-animate {
         -animation: spin 2.8s infinite linear;
         -webkit-animation: spinWebkit 2.8s infinite linear;

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/progressFieldset.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/progressFieldset.ftl
@@ -1,8 +1,9 @@
 <!-- progressbar -->
-<ul id="progressbar">
-    <li class="active" id="affirmation"><strong>Affirmation</strong></li>
-    <li id="billing"><strong>Billing</strong></li>
-    <li id="vault-info"><strong>Vault Info</strong></li>
-    <li id="vault-access"><strong>Vault Access</strong></li>
-    <li id="vault-summary"><strong>Summary</strong></li>
+<ul id="progressbar" role="progressbar" aria-valuenow="1" aria-valuemin="1" 
+    aria-valuemax="5" aria-valuetext="Affirmation">
+    <li class="active" id="affirmation" data-progress-text="Affirmation" data-progress-value="1"><strong>Affirmation</strong></li>
+    <li id="billing" data-progress-text="Billing" data-progress-value="2"><strong>Billing</strong></li>
+    <li id="vault-info" data-progress-text="Vault Information" data-progress-value="3"><strong>Vault Info</strong></li>
+    <li id="vault-access" data-progress-text="Vault Access" data-progress-value="4"><strong>Vault Access</strong></li>
+    <li id="vault-summary" data-progress-text="summary" data-progress-value="5"><strong>Summary</strong></li>
 </ul>

--- a/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
+++ b/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
@@ -367,6 +367,14 @@ $(document).ready(function(){
 
         //Add Class Active
         $("#progressbar li").eq($("fieldset").index(next_fs)).addClass("active");
+        // Add aria-* attributes to progress bar
+       
+        var currentProgressText = $("#progressbar > li.active").last().attr("data-progress-text");
+        var currentProgressValue = $("#progressbar > li.active").last().attr("data-progress-value");
+        console.log("currentProgressText: ", currentProgressText);
+        console.log("currentProgressValue: ", currentProgressValue);
+        $("#progressbar").attr("aria-valuetext", currentProgressText);
+        $("#progressbar").attr("aria-valuenow", currentProgressValue);
 
         //show the next fieldset
         next_fs.show();

--- a/datavault-webapp/src/main/webapp/resources/theme/css/createVault.css
+++ b/datavault-webapp/src/main/webapp/resources/theme/css/createVault.css
@@ -126,7 +126,7 @@
 
 #progressbar li.active:before,
 #progressbar li.active:after {
-    background: skyblue
+    background: #046B99;
 }
 
 #billing-selection-box {


### PR DESCRIPTION
…s bar"

Changes:
 - Active color for progress bar changed to "accessible blue" #046B99
based on web site "Accessible color palette builder" https://toolness.github.io/accessible-color-matrix/
- Added role="progressbar" and  aria-* attributes to progress bar
<ul id="progressbar" role="progressbar" aria-valuenow="1" aria-valuemin="1"
    aria-valuemax="5" aria-valuetext="Affirmation">
The values aria-valuenow and aria-valuetext are changed based on
progress.
- Changed color for progress bar on the "View the deposit" page to
"accessible blue" #046B99.

![Selection_059](https://user-images.githubusercontent.com/8876215/146788032-29f1b6b7-48ec-447b-984f-fa1ee7a7ec7a.png)
![Selection_062](https://user-images.githubusercontent.com/8876215/146789124-a8d6f9a9-7dfb-46c4-97a1-b8c43266a3ae.png)

![Selection_063](https://user-images.githubusercontent.com/8876215/146790082-d47e4423-07f4-4d9d-a8fe-4ce4999f6847.png)
![Selection_060](https://user-images.githubusercontent.com/8876215/146790129-acdf2355-08ed-4893-9f31-37fa7e87070d.png)
