### PR TITLE
Fix to ensure better contrast of text for Accessibility reasons.

### DIFF
--- a/datavault-webapp/src/main/webapp/resources/theme/css/createVault.css
+++ b/datavault-webapp/src/main/webapp/resources/theme/css/createVault.css
@@ -33,7 +33,7 @@
 
 #vault-creation-form fieldset .form-card {
     text-align: left;
-    color: #9E9E9E
+    color: #000;
 }
 
 .card {

--- a/datavault-webapp/src/main/webapp/resources/theme/css/overrideStyles.css
+++ b/datavault-webapp/src/main/webapp/resources/theme/css/overrideStyles.css
@@ -7,3 +7,30 @@
     background-color: #337ab7;
     border-color: #337ab7;
 }
+
+/* Overriding Edgel defaults for better Accessibility contrast */
+
+body {
+	color: #000;
+}
+
+.h3, .h4, .h5, .h6, h3, h4, h5, h6 {
+    color: #000;
+}
+
+p {
+	color: #000;
+}
+
+.small, cite, small {
+   color: #000;
+}
+
+/* A more accessible blue link http://web-accessibility.carnegiemuseums.org/design/color/ */
+a {
+	color: #0071bc;
+}
+
+.text-muted {
+	color: #000;
+}


### PR DESCRIPTION
Changes:
- overriden most of the textual color provided by Edgel to
black #000.
- overriden .text-muted css to #000.
- changed <a> tag normal color to #0071bc a more accesible blue
(cf. http://web-accessibility.carnegiemuseums.org/design/color/).

Some images of changes:
![Selection_075](https://user-images.githubusercontent.com/8876215/147239538-cf42bf90-2fdd-4e89-a6b7-f602ba1bc44c.png)
![Selection_074](https://user-images.githubusercontent.com/8876215/147239540-6d56c91e-8e2f-487a-8e8b-4aa342b5d1b4.png)
![Selection_073](https://user-images.githubusercontent.com/8876215/147239541-b13b9cdf-db0b-4f58-9aa9-3826ba95deac.png)
![Selection_072](https://user-images.githubusercontent.com/8876215/147239543-96a3dc20-3dbd-4b4f-8089-69cfd2e1b49a.png)
![Selection_071](https://user-images.githubusercontent.com/8876215/147239545-bc92da31-c1e2-4a85-a5fc-20564d3d2b38.png)
![Selection_070](https://user-images.githubusercontent.com/8876215/147239547-7a04806c-75f4-485a-a8a0-0000ee815896.png)
![Selection_069](https://user-images.githubusercontent.com/8876215/147239549-1d50e847-42fe-4986-bc48-905aba12ba2d.png)
![Selection_068](https://user-images.githubusercontent.com/8876215/147239552-844bc3ae-b0aa-4bc2-b839-c868257b0a58.png)
.