### PR TITLE
IssueID #RSS212-226 Fix broken links in Vault Created email

### DIFF
--- a/datavault-assembly/src/datavault-home/config/mail-templates/user-vault-create.vm
+++ b/datavault-assembly/src/datavault-home/config/mail-templates/user-vault-create.vm
@@ -10,7 +10,7 @@
         <li>Review date: ${vault-review-date}</li>
         <li>Role: ${role-name}</li>
     </ul>
-    <p>You may view the details of your vault by logging in with EASE at <a href=${home-page}>${home-page}</a>.
+    <p>You may view the details of your vault by logging in with your university login at <a href=${home-page}>${home-page}</a>.
         Further information about the service is available at <a href=${help-page}>${help-page}</a>.
     </p>
 </body>

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/VaultsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/VaultsService.java
@@ -113,8 +113,8 @@ public class VaultsService {
 
     private void sendEmail(Vault vault, String email, String subject, String role, String template, String homePage, String helpPage) {
         HashMap<String, Object> model = new HashMap<String, Object>();
-        model.put("homepage", homePage);
-        model.put("helppage", helpPage);
+        model.put("home-page", homePage);
+        model.put("help-page", helpPage);
         model.put("vault-name", vault.getName());
         model.put("group-name", vault.getGroup().getName());
         model.put("vault-id", vault.getID());


### PR DESCRIPTION
1) Updated VaultsService so that the correct template keys are used for the link values
2) Fixed the reference to EASE in the user-vault-create.vm text