### PR TITLE
RSS212-255 - Reverted the footer paragraph text "The University of

### DIFF
--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/layout/footer.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/layout/footer.ftl
@@ -37,7 +37,7 @@
                     </a>
                 </div>
                 <div class="col-sm-8 col-sm-pull-4">
-                    <p>
+                    <p style="color: #ccc;">
                         The University of Edinburgh is a charitable body, registered in Scotland, with registration number
                         SC005336, VAT Registration Number GB&nbsp;592&nbsp;9507&nbsp;00, and is acknowledged by the UK authorities as a
                         “<a href="https://www.gov.uk/guidance/recognised-uk-degrees">Recognised body</a>” which has been


### PR DESCRIPTION
Edinburgh is a charitable body..." to original colour #ccc.

For context, the original .p color #ccc from EDGel is overridden in
overrideStyles.css for contrast in site in general. So we have done
an inline change in footer <p style="color: #ccc;"> to revert to
original colour.