### PR TITLE
RSS408-23 - Changed the colour contrast for invalid error messages from

### DIFF
--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/pendingVaults/summary.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/pendingVaults/summary.ftl
@@ -107,7 +107,7 @@
 			<#if pendingVault.confirmed?c=="true">
                 <input class="form-control" id="reviewDate" placeholder="yyyy-mm-dd" name="reviewDate"
                      value="${pendingVault.getReviewDateAsString()}"/>
-                <span id="invalid-review-date-span" style="font-size: 1.2em; font: bold; color: #f00; display: inline;"></span>
+                <span id="invalid-review-date-span" style="font-size: 1.2em; font: bold; color:  #AE0F0F; display: inline;"></span>
             <#else>
                 <#if (pendingVault.reviewDate)??>
                     ${pendingVault.reviewDate?date}

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/billingFieldset.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/billingFieldset.ftl
@@ -82,7 +82,7 @@
                         <@spring.bind "vault.billingGrantEndDate" />
                         <input id="billingGrantEndDate" class="form-control date-picker" placeholder="yyyy-mm-dd" name="${spring.status.expression}"
                                value="${spring.status.value!""}"/>
-                         <span id="invalid-billing-grant-end-date-span" style="font-size: 1.2em; font: bold; color: #f00; display: inline;"></span>
+                         <span id="invalid-billing-grant-end-date-span" style="font-size: 1.2em; font: bold; color:  #AE0F0F; display: inline;"></span>
                     </div>
                 </div>
             </div>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/infoFieldset.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/vaults/infoFieldset.ftl
@@ -35,7 +35,7 @@
             <@spring.bind "vault.grantEndDate" />
             <input id="grantEndDate" class="form-control date-picker" placeholder="yyyy-mm-dd" name="${spring.status.expression}"
                    value="${spring.status.value!""}"/>
-             <span id="invalid-grant-end-date-span" style="font-size: 1.2em; font: bold; color: #f00; display: inline;"></span>
+             <span id="invalid-grant-end-date-span" style="font-size: 1.2em; font: bold; color:  #AE0F0F; display: inline;"></span>
         </div>
 
         <div class="alert alert-info" role="alert">
@@ -79,7 +79,7 @@
             <input class="form-control" id="reviewDate" placeholder="yyyy-mm-dd" name="${spring.status.expression}"
                    value="${spring.status.value!""}"/>
                     <span id="updated-review-date-span" style="font-size: 1.2em; font: bold; color: #006400; display: inline;"></span>
-                   <span id="invalid-review-date-span" style="font-size: 1.2em; font: bold; color: #f00; display: inline;"></span>
+                   <span id="invalid-review-date-span" style="font-size: 1.2em; font: bold; color:  #AE0F0F; display: inline;"></span>
         </div>
 
         <div class="form-group required">


### PR DESCRIPTION


The Color Contrast ratio is now 7.3:1. This passes all WCAG Accessibility tests.

![Selection_014](https://user-images.githubusercontent.com/8876215/165776563-cb08b6e1-8788-459f-b8cb-8f8af34e3f5d.png)

![Selection_012](https://user-images.githubusercontent.com/8876215/165776567-ff47aec5-fdac-4089-9c60-8f445404a57e.png)

This color #006400 already satisfies WCAG Accessibility tests.
![Selection_015](https://user-images.githubusercontent.com/8876215/165777291-16e04234-b4dc-4852-85eb-29cdf4ccf27c.png)
![Selection_013](https://user-images.githubusercontent.com/8876215/165777810-3e8f9f34-4524-4c16-b1e6-9059307e5dec.png)
