### PR TITLE
#RSS408-206 Add sleep for a couple of seconds as a quick fix to multi deposit retrievals

### DIFF
--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystem.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystem.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 public class SFTPFileSystem extends Device implements UserStore {
 
@@ -341,6 +342,7 @@ public class SFTPFileSystem extends Device implements UserStore {
             channelSftp.cd(path);
 
             // Create timestamped folder to avoid overwriting files
+            TimeUnit.SECONDS.sleep(2);
             String timeStamp = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
             String timestampDirName = "dv_" + timeStamp;
             path = path + PATH_SEPARATOR + timestampDirName;


### PR DESCRIPTION


1). Updated SFTPFileSystem.java store method to sleep for a couple of seconds before creating the timestamp used in the dir name this. should stop the bug
where the same dir name is being used and causing sftp to throw an error.