### PR TITLE
IssueID #RSS408-214 Change default filed default to null from 0.0

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/VaultsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/VaultsService.java
@@ -317,8 +317,8 @@ public class VaultsService {
 
     public void addBillingInfo(CreateVault createVault, Vault vault) {
         BillingInfo billinginfo =  new BillingInfo();
-        billinginfo.setAmountBilled(new BigDecimal(0));
-        billinginfo.setAmountToBeBilled(new BigDecimal(0));
+        billinginfo.setAmountBilled(null);
+        billinginfo.setAmountToBeBilled(null);
         billinginfo.setVault(vault);
         String billingType = createVault.getBillingType();
 


### PR DESCRIPTION
1) Updated VaultsService.addBillingInfo so that the default value for a new vault is null rather than 0.0.

It doesn't look like the db schema needs changed as deploying this locally behaves as expected (blank displayed rather than 0.0), actually adding values afterwards worked too.