### PR TITLE
RSS408-230 - Further fixes for calculating Review Date for a vault.

### DIFF
--- a/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
+++ b/datavault-webapp/src/main/webapp/resources/application/js/new-create-prototype.js
@@ -70,12 +70,12 @@ $(document).ready(function(){
 				$("#grantEndDate").prop("disabled", true);
 			} else {
 				var length = calculateReviewLength();
-				var estimatedReviewDate = calculateReviewDateForToday(length);
-
+				var estimatedReviewDateAsISOString = calculateReviewDateForTodayAsISOString(length);
+				estimatedReviewDateAsISOString = validateOrChangeReviewDateISOString(estimatedReviewDateAsISOString);
 				$("#grantEndDate").prop("disabled", false);
 				// Reset to dbGrantEndDate
 				$("#grantEndDate").val(dbGrantEndDate);
-				$("#reviewDate").val(estimatedReviewDate);
+				$("#reviewDate").val(estimatedReviewDateAsISOString);
 			}
 		}
 	}).trigger('change');
@@ -112,7 +112,7 @@ $(document).ready(function(){
 			var dd = String(today.getDate()).padStart(2, '0');
 			var mm = String(today.getMonth() + 1).padStart(2, '0'); // January is 0
 			// Default Review Date (3 years from today)
-			var estimatedReviewDate = calculateReviewDateForToday(defaultLength);
+			var estimatedReviewDateAsISOString = calculateReviewDateForTodayAsISOString(defaultLength);
 			
 			// GED in future test
 			var grantGEDInFuture = noGED  ? false : (dateDiffInDaysStartingAtMidnight(today, gedDate) > 0);
@@ -120,42 +120,40 @@ $(document).ready(function(){
             
 			if (noRP === false && noGED === true && noBillingGED === true) {
 				// if we only have policy then length + current date = review date
-				estimatedReviewDate = String(today.getFullYear() + policyLength) + '-' + mm + '-' + dd;
+				estimatedReviewDateAsISOString = String(today.getFullYear() + policyLength) + '-' + mm + '-' + dd;
 			} 
 			
 			if (noRP === false && noBillingGED === false && billingGEDInFuture === true) {
 				// if we have both then billing ged + policy length = review date
-				estimatedReviewDate = String(billingGedDate.getFullYear() + policyLength) + '-' + billingGedMm + '-' + billingGedDd;
+				estimatedReviewDateAsISOString = String(billingGedDate.getFullYear() + policyLength) + '-' + billingGedMm + '-' + billingGedDd;
 			} 
 			
 			if (noRP === true && noBillingGED === false && billingGEDInFuture === true) {
 				// if we only have a ged in the billing fieldset then ged + 3 = review date
-				estimatedReviewDate = String(billingGedDate.getFullYear() + defaultLength) + '-' + billingGedMm + '-' + billingGedDd;
+				estimatedReviewDateAsISOString = String(billingGedDate.getFullYear() + defaultLength) + '-' + billingGedMm + '-' + billingGedDd;
+			
 			} 
 			
 			if (noRP === false && noGED === false && grantGEDInFuture === true) {
 				// if we have both then ged + policy length = review date
-				estimatedReviewDate = String(gedDate.getFullYear() + policyLength) + '-' + gedMm + '-' + gedDd;
+				estimatedReviewDateAsISOString = String(gedDate.getFullYear() + policyLength) + '-' + gedMm + '-' + gedDd;
 			} 
 			
 			if (noRP === true && noGED === false && grantGEDInFuture === true) {
 				// if we only have ged then ged + 3 = review date
-				estimatedReviewDate = String(gedDate.getFullYear() + defaultLength) + '-' + gedMm + '-' + gedDd;
+				estimatedReviewDateAsISOString = String(gedDate.getFullYear() + defaultLength) + '-' + gedMm + '-' + gedDd;
 			} 
 			
 			if (noRP === false && noBillingGED === false && billingGEDInFuture === false) {
-				// if we only have policy then length + current date = review date
-				estimatedReviewDate = String(today.getFullYear() + policyLength) + '-' + mm + '-' + dd;
+				estimatedReviewDateAsISOString = String(billingGedDate.getFullYear() + policyLength) + '-' + billingGedMm + '-' + billingGedDd;
 			} 
 			
 			if (noRP === false && noGED === false && grantGEDInFuture === false) {
-				// if we only have policy then length + current date = review date
-				estimatedReviewDate = String(today.getFullYear() + policyLength) + '-' + mm + '-' + dd;
+				estimatedReviewDateAsISOString = String(gedDate.getFullYear() + policyLength) + '-' + gedMm + '-' + gedDd;
 			}
 			
-			
-
-			$("#reviewDate").val(estimatedReviewDate);
+			estimatedReviewDateAsISOString = validateOrChangeReviewDateISOString(estimatedReviewDateAsISOString);
+			$("#reviewDate").val(estimatedReviewDateAsISOString);
 
 			// Clear Error text and update message 
 			$("#invalid-review-date-span").text(""); 
@@ -589,11 +587,13 @@ $(document).ready(function(){
 				$("#grantEndDate").prop("disabled", true);
 			} else {
 				var length = calculateReviewLength();
-				var estimatedReviewDate = calculateReviewDateForToday(length);
+				var estimatedReviewDateAsISOString = calculateReviewDateForTodayAsISOString(length);
+				estimatedReviewDateAsISOString = validateOrChangeReviewDateISOString(estimatedReviewDateAsISOString);
 				$("#grantEndDate").prop("disabled", false);
 				// Reset to dbGrantEndDate
 				$("#grantEndDate").val(dbGrantEndDate);
-				$("#reviewDate").val(estimatedReviewDate);
+				
+				$("#reviewDate").val(estimatedReviewDateAsISOString);
 			}
 
 			// clear the unused fieldsets
@@ -732,7 +732,7 @@ $(document).ready(function(){
 
 	}
 
-	function calculateReviewDateForToday(length) {
+	function calculateReviewDateForTodayAsISOString(length) {
 		var today = new Date();
 		var dd = String(today.getDate()).padStart(2,'0');
 		var mm = String(today.getMonth() + 1).padStart(2,'0'); // January is 0
@@ -756,6 +756,20 @@ $(document).ready(function(){
 		}
 
 		return length;
+	}
+	
+	function validateOrChangeReviewDateISOString(reviewDateToCheckISOString) {
+		console.log("validateOrChangeReviewDate - reviewDateToCheckISOString: ", reviewDateToCheckISOString);
+		var reviewDateToCheckObject = new Date(reviewDateToCheckISOString);
+		var today = new Date();
+		var diffInYears = dateDiffInYears(today, reviewDateToCheckObject);
+		// Default Review Date 3 years from today.
+		var defaultLength = 3;
+		if(diffInYears < defaultLength) {
+			return calculateReviewDateForTodayAsISOString(defaultLength);
+		} else {
+			return reviewDateToCheckISOString;
+		}
 	}
 });
 


### PR DESCRIPTION
Changes to satisfy algorithm:

The minimum review date for any vault is 3 years in the future. So in order to help the user, we pre-populate the Review date field in the create-vault form to 3 years hence. In addition to validation checking the 3 years when they submit the form.

Default value in absence of retention policy:

Today + 3 years => default Review Date

eg 2021-10-14 + 3 years => Review Date is 2024-10-14

The DataVault should re-calculate the Review Date as soon as the value of the Grant End Date (GED) or Retention Policy fields change. This is a two-step calculation in terms of the dates:

Grant End Date + Retention Policy => Compliance date;

If Compliance date <= three years in the future, Default review date remains 3 years from now;

Else Default review date = Compliance date

e.g.

If GED is 2002-07-31 + Retention Policy is 5 years and today's date is 2022-09-28

=> Compliance date was in 2007 (we never suggest a review date less than 3 years in the future)

 => minimum storage period is applicable

 = > Review date is 2025-09-28.

If GED is 2021-10-31 + Retention Policy is 5 years and today's date is 2022-09-28

 => Compliance date is 2026, which is further away than the minimum storage period, so the review date should be set to the compliance date

=> Review date is 2026-10-31.