### PR TITLE
Dv 5 upgrade - reduce worker memory usage and added /actuator/memoryinfo endpoints

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/actuator/MemoryInfo.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/actuator/MemoryInfo.java
@@ -1,0 +1,22 @@
+package org.datavaultplatform.broker.actuator;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class MemoryInfo {
+
+  private final Map<String, Object> memDetails;
+
+  public MemoryInfo(Map<String, Object> memDetails) {
+    this.memDetails = memDetails;
+  }
+
+  @JsonAnyGetter
+  public Map<String, Object> getMemDetails() {
+    return this.memDetails;
+  }
+}
+

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/actuator/MemoryInfoEndpoint.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/actuator/MemoryInfoEndpoint.java
@@ -1,0 +1,48 @@
+package org.datavaultplatform.broker.actuator;
+
+import org.datavaultplatform.common.monitor.MemoryStats;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Endpoint(id="memoryinfo")
+public class MemoryInfoEndpoint {
+  public static final String MEMORY = "memory";
+  public static final String TIMESTAMP = "timestamp";
+
+  public static final String MEMORY_FREE = "free";
+  public static final String MEMORY_MAX = "max";
+  public static final String MEMORY_TOTAL = "total";
+
+  private final Clock clock;
+  public MemoryInfoEndpoint(Clock clock){
+    this.clock = clock;
+  }
+  @ReadOperation
+  public MemoryInfo memoryInfo() {
+    Map<String,Object> inner = new LinkedHashMap<>();
+    MemoryStats stats = MemoryStats.getCurrent();
+    inner.put(MEMORY_FREE, MemoryStats.humanReadableByteCountSI(stats.getFreeMemory()));
+    inner.put(MEMORY_TOTAL, MemoryStats.humanReadableByteCountSI(stats.getTotalMemory()));
+    inner.put(MEMORY_MAX, MemoryStats.humanReadableByteCountSI(stats.getMaxMemory()));
+
+    Map<String, Object> outer = new LinkedHashMap<>();
+
+    ZonedDateTime zdt = clock.instant().atZone(ZoneOffset.UTC);
+    String timestamp = zdt.format(DateTimeFormatter.ISO_INSTANT);
+
+    outer.put(TIMESTAMP, timestamp);
+    outer.put(MEMORY, inner);
+
+    MemoryInfo info = new MemoryInfo(outer);
+    return info;
+  }
+
+}

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/config/ActuatorConfig.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/config/ActuatorConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.function.Function;
 import org.datavaultplatform.broker.actuator.CurrentTimeEndpoint;
 import org.datavaultplatform.broker.actuator.LocalFileStoreEndpoint;
+import org.datavaultplatform.broker.actuator.MemoryInfoEndpoint;
 import org.datavaultplatform.broker.actuator.SftpFileStoreEndpoint;
 import org.datavaultplatform.broker.services.ArchiveStoreService;
 import org.datavaultplatform.broker.services.FileStoreService;
@@ -25,6 +26,11 @@ public class ActuatorConfig {
   @Bean
   CurrentTimeEndpoint currentTime(Clock clock){
     return new CurrentTimeEndpoint(clock);
+  }
+
+  @Bean
+  MemoryInfoEndpoint memoryInfoEndpoint(Clock clock) {
+    return new MemoryInfoEndpoint(clock);
   }
 
   @Bean

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/config/SecurityActuatorConfig.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/config/SecurityActuatorConfig.java
@@ -41,7 +41,8 @@ public class SecurityActuatorConfig extends WebSecurityConfigurerAdapter {
         .httpBasic().and()
         .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
         .authorizeRequests()
-          .antMatchers("/actuator/health", "/actuator/info").permitAll()
+          .antMatchers("/actuator/health", "/actuator/info",
+            "/actuator/metrics", "/actuator/metrics/*", "/actuator/memoryinfo").permitAll()
           .anyRequest().authenticated();
   }
 }

--- a/datavault-broker/src/main/resources/application.properties
+++ b/datavault-broker/src/main/resources/application.properties
@@ -40,7 +40,7 @@ management.info.java.enabled=true
 management.info.os.enabled=true
 management.endpoint.health.show-details=always
 management.endpoint.health.show-components=always
-management.endpoints.web.exposure.include=health,info,scheduledtasks,customtime,sftpfilestores,localfilestores
+management.endpoints.web.exposure.include=health,info,scheduledtasks,customtime,sftpfilestores,localfilestores,metrics,memoryinfo
 
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG
 

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/actuator/MemoryInfo.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/actuator/MemoryInfo.java
@@ -1,0 +1,22 @@
+package org.datavaultplatform.webapp.actuator;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class MemoryInfo {
+
+  private final Map<String, Object> memDetails;
+
+  public MemoryInfo(Map<String, Object> memDetails) {
+    this.memDetails = memDetails;
+  }
+
+  @JsonAnyGetter
+  public Map<String, Object> getMemDetails() {
+    return this.memDetails;
+  }
+}
+

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/actuator/MemoryInfoEndpoint.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/actuator/MemoryInfoEndpoint.java
@@ -1,0 +1,49 @@
+package org.datavaultplatform.webapp.actuator;
+
+import org.datavaultplatform.common.monitor.MemoryStats;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+
+import java.time.Clock;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Endpoint(id="memoryinfo")
+public class MemoryInfoEndpoint {
+  public static final String MEMORY = "memory";
+  public static final String TIMESTAMP = "timestamp";
+
+  public static final String MEMORY_FREE = "free";
+  public static final String MEMORY_MAX = "max";
+  public static final String MEMORY_TOTAL = "total";
+
+  private final Clock clock;
+
+  public MemoryInfoEndpoint(Clock clock){
+    this.clock = clock;
+  }
+
+  @ReadOperation
+  public MemoryInfo memoryInfo() {
+    Map<String,Object> inner = new LinkedHashMap<>();
+    MemoryStats stats = MemoryStats.getCurrent();
+    inner.put(MEMORY_FREE, MemoryStats.humanReadableByteCountSI(stats.getFreeMemory()));
+    inner.put(MEMORY_TOTAL, MemoryStats.humanReadableByteCountSI(stats.getTotalMemory()));
+    inner.put(MEMORY_MAX, MemoryStats.humanReadableByteCountSI(stats.getMaxMemory()));
+
+    Map<String, Object> outer = new LinkedHashMap<>();
+
+    ZonedDateTime zdt = clock.instant().atZone(ZoneOffset.UTC);
+    String timestamp = zdt.format(DateTimeFormatter.ISO_INSTANT);
+
+    outer.put(TIMESTAMP, timestamp);
+    outer.put(MEMORY, inner);
+
+    MemoryInfo info = new MemoryInfo(outer);
+    return info;
+  }
+
+}

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/authentication/shib/ShibAuthenticationFilter.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/authentication/shib/ShibAuthenticationFilter.java
@@ -21,7 +21,8 @@ import org.springframework.util.Assert;
  */
 public class ShibAuthenticationFilter extends AbstractPreAuthenticatedProcessingFilter {
 
-    public static final String[] BYPASS_STARTING_WITH = {"/error", "/resources", "/actuator/info","/actuator/health", "/actuator/customtime"};
+    public static final String[] BYPASS_STARTING_WITH = {"/error", "/resources", "/actuator/info","/actuator/health",
+            "/actuator/customtime", "/actuator/metrics", "/actuator/memoryinfo"};
 
     private String principalRequestHeader;
     private boolean exceptionIfHeaderMissing = true;

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/config/ActutatorConfig.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/config/ActutatorConfig.java
@@ -2,6 +2,7 @@ package org.datavaultplatform.webapp.config;
 
 import java.time.Clock;
 import org.datavaultplatform.webapp.actuator.CurrentTimeEndpoint;
+import org.datavaultplatform.webapp.actuator.MemoryInfoEndpoint;
 import org.springframework.boot.SpringBootVersion;
 import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.context.annotation.Bean;
@@ -18,6 +19,11 @@ public class ActutatorConfig {
   @Bean
   CurrentTimeEndpoint currentTime(Clock clock){
       return new CurrentTimeEndpoint(clock);
+  }
+
+  @Bean
+  MemoryInfoEndpoint memoryInfo(Clock clock) {
+    return new MemoryInfoEndpoint(clock);
   }
 
   @Bean

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/config/SecurityActuatorConfig.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/config/SecurityActuatorConfig.java
@@ -49,7 +49,8 @@ public class SecurityActuatorConfig extends WebSecurityConfigurerAdapter {
             "/actuator",
             "/actuator/info",
             "/actuator/health",
-            "/actuator/customtime").permitAll()
+            "/actuator/customtime",
+            "/actuator/metrics", "/actuator/metrics/*", "/actuator/memoryinfo").permitAll()
         .anyRequest().authenticated();
   }
 

--- a/datavault-webapp/src/main/resources/application.properties
+++ b/datavault-webapp/src/main/resources/application.properties
@@ -34,7 +34,7 @@ management.info.java.enabled=true
 management.info.os.enabled=true
 management.endpoint.health.show-details=always
 management.endpoint.health.show-components=always
-management.endpoints.web.exposure.include=health,info,customtime
+management.endpoints.web.exposure.include=health,info,customtime,metrics,memoryinfo
 
 webapp.actuator.username=wactor
 webapp.actuator.password=wactorpass

--- a/datavault-webapp/src/test/java/org/datavaultplatform/webapp/app/setup/ActuatorTest.java
+++ b/datavault-webapp/src/test/java/org/datavaultplatform/webapp/app/setup/ActuatorTest.java
@@ -45,7 +45,7 @@ import org.springframework.test.web.servlet.ResultActions;
 @TestPropertySource(properties = "management.endpoints.web.exposure.include=*")
 public class ActuatorTest {
 
-  private static final List<String> PUBLIC_ENDPOINTS = Arrays.asList("info","health","customtime");
+  private static final List<String> PUBLIC_ENDPOINTS = Arrays.asList("info","health","customtime", "metrics", "memoryinfo");
   private static final List<String> PRIVATE_ENDPOINTS = Arrays.asList("env","loggers","mappings","beans");
 
   @Autowired
@@ -115,6 +115,28 @@ public class ActuatorTest {
     assertTrue(infoMap.containsKey("current-time"));
     String ct = infoMap.get("current-time");
     Assertions.assertEquals("Tue Mar 29 14:15:16 BST 2022",ct);
+  }
+
+  @Test
+  void testMemoryInfo() throws Exception {
+    MvcResult mvcResult = mvc.perform(
+                    get("/actuator/memoryinfo"))
+            .andExpect(content().contentTypeCompatibleWith("application/vnd.spring-boot.actuator.v3+json"))
+            .andExpect(jsonPath("$.memory").exists())
+            .andReturn();
+
+    String json = mvcResult.getResponse().getContentAsString();
+    Map<String,Object> infoMap = mapper.createParser(json).readValueAs(Map.class);
+
+    String ct = (String)infoMap.get("timestamp");
+    Assertions.assertEquals("2022-03-29T13:15:16.101Z",ct);
+
+    assertTrue(infoMap.containsKey("memory"));
+    Map<String,Object> innerMap = (Map<String,Object>)infoMap.get("memory");
+    assertTrue(innerMap.containsKey("total"));
+    assertTrue(innerMap.containsKey("free"));
+    assertTrue(innerMap.containsKey("max"));
+
   }
 
   @Test

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/actuator/MemoryInfo.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/actuator/MemoryInfo.java
@@ -1,0 +1,22 @@
+package org.datavaultplatform.worker.actuator;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class MemoryInfo {
+
+  private final Map<String, Object> memDetails;
+
+  public MemoryInfo(Map<String, Object> memDetails) {
+    this.memDetails = memDetails;
+  }
+
+  @JsonAnyGetter
+  public Map<String, Object> getMemDetails() {
+    return this.memDetails;
+  }
+}
+

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/actuator/MemoryInfoEndpoint.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/actuator/MemoryInfoEndpoint.java
@@ -1,0 +1,48 @@
+package org.datavaultplatform.worker.actuator;
+
+import org.datavaultplatform.common.monitor.MemoryStats;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Endpoint(id="memoryinfo")
+public class MemoryInfoEndpoint {
+  public static final String MEMORY = "memory";
+  public static final String TIMESTAMP = "timestamp";
+
+  public static final String MEMORY_FREE = "free";
+  public static final String MEMORY_MAX = "max";
+  public static final String MEMORY_TOTAL = "total";
+
+  private final Clock clock;
+  public MemoryInfoEndpoint(Clock clock){
+    this.clock = clock;
+  }
+  @ReadOperation
+  public MemoryInfo memoryInfo() {
+    Map<String,Object> inner = new LinkedHashMap<>();
+    MemoryStats stats = MemoryStats.getCurrent();
+    inner.put(MEMORY_FREE, MemoryStats.humanReadableByteCountSI(stats.getFreeMemory()));
+    inner.put(MEMORY_TOTAL, MemoryStats.humanReadableByteCountSI(stats.getTotalMemory()));
+    inner.put(MEMORY_MAX, MemoryStats.humanReadableByteCountSI(stats.getMaxMemory()));
+
+    Map<String, Object> outer = new LinkedHashMap<>();
+
+    ZonedDateTime zdt = clock.instant().atZone(ZoneOffset.UTC);
+    String timestamp = zdt.format(DateTimeFormatter.ISO_INSTANT);
+
+    outer.put(TIMESTAMP, timestamp);
+    outer.put(MEMORY, inner);
+
+    MemoryInfo info = new MemoryInfo(outer);
+    return info;
+  }
+
+}

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/config/ActuatorConfig.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/config/ActuatorConfig.java
@@ -2,6 +2,7 @@ package org.datavaultplatform.worker.config;
 
 import java.time.Clock;
 import org.datavaultplatform.worker.actuator.CurrentTimeEndpoint;
+import org.datavaultplatform.worker.actuator.MemoryInfoEndpoint;
 import org.springframework.boot.SpringBootVersion;
 import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.context.annotation.Bean;
@@ -13,6 +14,11 @@ public class ActuatorConfig {
   @Bean
   Clock clock() {
     return Clock.systemDefaultZone();
+  }
+
+  @Bean
+  MemoryInfoEndpoint memoryInfoEndpoint(Clock clock) {
+    return new MemoryInfoEndpoint(clock);
   }
 
   @Bean

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/config/EventSenderConfig.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/config/EventSenderConfig.java
@@ -1,6 +1,7 @@
 package org.datavaultplatform.worker.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.datavaultplatform.common.event.EventSender;
 import org.datavaultplatform.common.event.RecordingEventSender;
 import org.datavaultplatform.worker.queue.RabbitEventSender;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -27,7 +28,17 @@ public class EventSenderConfig {
   String workerName;
 
   @Bean
-  public RecordingEventSender eventSender(ObjectMapper mapper) {
-    return new RecordingEventSender(new RabbitEventSender(template, brokerQueueName, workerName, sequenceStart, mapper));
+  public EventSender eventSender(ObjectMapper mapper,
+      @Value("${use.recording.event.sender:false}") boolean useRecordingEventSender) {
+    final EventSender result;
+    RabbitEventSender rabbitEventSender = new RabbitEventSender(template, brokerQueueName,
+        workerName,
+        sequenceStart, mapper);
+    if (useRecordingEventSender) {
+      result = new RecordingEventSender(rabbitEventSender);
+    } else {
+      result = rabbitEventSender;
+    }
+    return result;
   }
 }

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/config/ReceiverConfig.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/config/ReceiverConfig.java
@@ -5,7 +5,7 @@ import java.security.Security;
 import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.datavaultplatform.common.event.RecordingEventSender;
+import org.datavaultplatform.common.event.EventSender;
 import org.datavaultplatform.common.task.Context.AESMode;
 import org.datavaultplatform.common.util.StorageClassNameResolver;
 import org.datavaultplatform.worker.queue.Receiver;
@@ -47,7 +47,7 @@ public class ReceiverConfig {
   private boolean validateWorkerDirs;
 
   @Autowired
-  RecordingEventSender eventSender;
+  EventSender eventSender;
 
   /*
       <bean id="receiver" class="org.datavaultplatform.worker.queue.Receiver">

--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/config/SecurityActuatorConfig.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/config/SecurityActuatorConfig.java
@@ -44,7 +44,8 @@ public class SecurityActuatorConfig extends WebSecurityConfigurerAdapter {
         .httpBasic().and()
         .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
         .authorizeRequests()
-          .antMatchers("/actuator/health", "/actuator/info").permitAll()
+          .antMatchers("/actuator/health", "/actuator/info",
+            "/actuator/metrics", "/actuator/metrics/*", "/actuator/memoryinfo").permitAll()
           .anyRequest().authenticated();
   }
 }

--- a/datavault-worker/src/test/java/org/datavaultplatform/worker/actuator/ActuatorTest.java
+++ b/datavault-worker/src/test/java/org/datavaultplatform/worker/actuator/ActuatorTest.java
@@ -1,23 +1,30 @@
 package org.datavaultplatform.worker.actuator;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.Map;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.datavaultplatform.common.event.RecordingEventSender;
 import org.datavaultplatform.worker.app.DataVaultWorkerInstanceApp;
 import org.datavaultplatform.worker.test.AddTestProperties;
+import org.datavaultplatform.worker.test.TestClockConfig;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest(classes = DataVaultWorkerInstanceApp.class)
 @AddTestProperties
@@ -27,7 +34,11 @@ import org.springframework.test.web.servlet.MockMvc;
     "management.endpoints.web.exposure.include=*",
     "management.health.rabbit.enabled=false"})
 @AutoConfigureMockMvc
+@Import(TestClockConfig.class)
 public class ActuatorTest {
+
+  @Autowired
+  ObjectMapper mapper;
 
   @Autowired
   MockMvc mvc;
@@ -38,7 +49,7 @@ public class ActuatorTest {
   @Test
   @SneakyThrows
   void testActuatorPublicAccess() {
-    Stream.of("/actuator/info", "/actuator/health").forEach(this::checkPublic);
+    Stream.of("/actuator/info", "/actuator/health", "/actuator/metrics", "/actuator/memoryinfo").forEach(this::checkPublic);
   }
 
   @Test
@@ -70,4 +81,27 @@ public class ActuatorTest {
   void checkPublic(String url) {
     mvc.perform(get(url)).andDo(print()).andExpect(status().isOk());
   }
+
+  @Test
+  void testMemoryInfo() throws Exception {
+    MvcResult mvcResult = mvc.perform(
+                    get("/actuator/memoryinfo"))
+            .andExpect(content().contentTypeCompatibleWith("application/vnd.spring-boot.actuator.v3+json"))
+            .andExpect(jsonPath("$.memory").exists())
+            .andReturn();
+
+    String json = mvcResult.getResponse().getContentAsString();
+    Map<String,Object> infoMap = mapper.createParser(json).readValueAs(Map.class);
+
+    String ct = (String)infoMap.get("timestamp");
+    Assertions.assertEquals("2022-03-29T13:15:16.101Z",ct);
+
+    assertTrue(infoMap.containsKey("memory"));
+    Map<String,Object> innerMap = (Map<String,Object>)infoMap.get("memory");
+    assertTrue(innerMap.containsKey("total"));
+    assertTrue(innerMap.containsKey("free"));
+    assertTrue(innerMap.containsKey("max"));
+
+  }
+
 }

--- a/datavault-worker/src/test/java/org/datavaultplatform/worker/test/TestClockConfig.java
+++ b/datavault-worker/src/test/java/org/datavaultplatform/worker/test/TestClockConfig.java
@@ -1,0 +1,22 @@
+package org.datavaultplatform.worker.test;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+@TestConfiguration
+public class TestClockConfig {
+
+  @Bean
+  @Primary
+  public Clock testClock() {
+    return Clock.fixed(
+        Instant.parse("2022-03-29T13:15:16.101Z"),
+        ZoneId.of("Europe/London"));
+  }
+
+}

--- a/dv5/local/actuator/actuatorMemory.sh
+++ b/dv5/local/actuator/actuatorMemory.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+BASEDIR=$(dirname $0)
+. $BASEDIR/setup.sh
+
+
+/bin/echo -n "WEBAPP $HOST:$PORT_WEBAPP health is "; curl $CURL_OPTS http://$HOST:$PORT_WEBAPP/actuator/memoryinfo | jq
+/bin/echo -n "BROKER $HOST:$PORT_BROKER health is "; curl $CURL_OPTS http://$HOST:$PORT_BROKER/actuator/memoryinfo | jq
+/bin/echo -n "WORKER $HOST:$PORT_WORKER health is "; curl $CURL_OPTS http://$HOST:$PORT_WORKER/actuator/memoryinfo | jq


### PR DESCRIPTION
RecordingEventSender is now only used if boolean property 'use.recording.event.sender' is true (default is false)
