### PR TITLE
#DS-RSS408-241 Increase thread timeout for JS file size count

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/FilesService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/FilesService.java
@@ -30,7 +30,7 @@ public class FilesService {
 
     //TODO - DHAY this does not seem thread safe
     private UserStore userStore;
-    private final long TIMEOUT_SECONDS = 40;
+    private final long TIMEOUT_SECONDS = 300;
     
     private boolean connect(FileStore fileStore) {
         try {


### PR DESCRIPTION
Increase thread timeout for JS file size count, which will hopefully improve JS file size count.

More info in https://www.jira.is.ed.ac.uk/browse/RSS408-241