### PR TITLE
#DS-LUC070-14 Changed the Worker Events agent to be the temp dir name (so failed jobs restart again)

### DIFF
--- a/datavault-worker/src/main/java/org/datavaultplatform/worker/queue/RabbitEventSender.java
+++ b/datavault-worker/src/main/java/org/datavaultplatform/worker/queue/RabbitEventSender.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.datavaultplatform.common.event.Event;
 import org.datavaultplatform.common.event.EventSender;
 import org.datavaultplatform.common.model.Agent;
+import org.datavaultplatform.worker.WorkerInstance;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -51,7 +52,7 @@ public class RabbitEventSender implements EventSender {
 
         // Set common event properties
         event.setAgentType(Agent.AgentType.WORKER);
-        event.setAgent(workerName);
+        event.setAgent(WorkerInstance.getWorkerName());
         
         try {
             String jsonEvent = mapper.writeValueAsString(event);


### PR DESCRIPTION
Fixed a bug in the restart deposits job where the wrong temp dir was being used.