### PR TITLE
DS-LUC070-9-20240215

### DIFF
--- a/datavault-broker/src/test/java/org/datavaultplatform/broker/authentication/FileStoreControllerIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/broker/authentication/FileStoreControllerIT.java
@@ -333,7 +333,7 @@ public class FileStoreControllerIT extends BaseDatabaseTest {
     File tempFile = new File(this.tempFromSftp, "writeTest.txt");
     String randomContents = UUID.randomUUID().toString();
     writeToFile(tempFile, randomContents);
-    String storedPath = sftp.store("FILES/AAA", tempFile, new Progress());
+    String storedPath = sftp.store("FILES/AAA", tempFile, new Progress(), "dv_111111");
     //this file should now be stored on sftp file system
 
     Path relStoredPath = Paths.get(BASE_SFTP_DIR).relativize(Paths.get(storedPath));

--- a/datavault-broker/src/test/java/org/datavaultplatform/common/storage/BaseSFTPFileSystemIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/common/storage/BaseSFTPFileSystemIT.java
@@ -142,7 +142,7 @@ public abstract class BaseSFTPFileSystemIT {
   @Test
   @SneakyThrows
   void testUsableSpace() {
-    assertThat(getSftpDriver().getUsableSpace()).isGreaterThan(50_000_000_000L);
+    assertThat(getSftpDriver().getUsableSpace()).isGreaterThan(10_000_000_000L);
   }
 
   @Test
@@ -161,7 +161,7 @@ public abstract class BaseSFTPFileSystemIT {
     getLog().info("sftpDriver {}", getSftpDriver());
 
     Progress p1 = new Progress();
-    String pathOnRemote = getSftpDriver().store(".", fromDvFile, p1);
+    String pathOnRemote = getSftpDriver().store(".", fromDvFile, p1, "dv_20220326094433");
 
     if(getSftpDriver().isMonitoring()) {
       assertEquals(fromDvFile.length(), p1.getByteCount());
@@ -237,7 +237,7 @@ public abstract class BaseSFTPFileSystemIT {
     getLog().info("sftpDriver {}", getSftpDriver());
 
     Progress p1 = new Progress();
-    String pathOnRemote = getSftpDriver().store(".", fromDvFile, p1);
+    String pathOnRemote = getSftpDriver().store(".", fromDvFile, p1, "dv_20220326094433");
 
     if(getSftpDriver().isMonitoring()) {
       assertEquals(fromDvFile.length(), p1.getByteCount());
@@ -329,7 +329,8 @@ public abstract class BaseSFTPFileSystemIT {
     ProgressEventListener sendListener = sendEvents::add;
     Progress pSend = new Progress(sendListener);
     File largeFileSend = createLargeFile(tempFileDir, fileSize);
-    String pathOnRemote = time(label, "store", () -> getSftpDriver().store(".", largeFileSend, pSend));
+    String pathOnRemote = time(label, "store", () -> getSftpDriver().store(".", largeFileSend, pSend,
+            "dv_20220326094433"));
     Path tsPath = Paths.get(SFTP_ROOT_DIR).relativize(Paths.get(pathOnRemote));
 
     String largeFileRemotePath = tsPath.resolve(largeFileSend.getName()).toString();
@@ -433,7 +434,7 @@ public abstract class BaseSFTPFileSystemIT {
     getLog().info("sftpDriver {}", getSftpDriver());
 
     Progress p1 = new Progress();
-    String pathOnRemote = getSftpDriver().store(".", fromDvDir, p1);
+    String pathOnRemote = getSftpDriver().store(".", fromDvDir, p1, "dv_20220326094433");
     if(getSftpDriver().isMonitoring()) {
       assertEquals(fromDvDirFileA.length() + fromDvDirFileB.length() + fromDvDirFileC.length(),
           p1.getByteCount());
@@ -566,7 +567,7 @@ public abstract class BaseSFTPFileSystemIT {
     getLog().info("sftpDriver {}", getSftpDriver());
 
     Progress p1 = new Progress();
-    String pathOnRemote = getSftpDriver().store(".", fromDvDir, p1);
+    String pathOnRemote = getSftpDriver().store(".", fromDvDir, p1, "dv_20220326094433");
 
     Path tsPath = Paths.get(SFTP_ROOT_DIR).relativize(Paths.get(pathOnRemote));
     Path retrievePath = tsPath.resolve(fromDvDir.toPath().getFileName());

--- a/datavault-broker/src/test/java/org/datavaultplatform/common/storage/SFTPFileSystemPerformanceIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/common/storage/SFTPFileSystemPerformanceIT.java
@@ -56,7 +56,7 @@ public class SFTPFileSystemPerformanceIT {
   static final int TEST_SFTP_SERVER_PORT = 2222;
   static final int TEST_ITERATIONS = 5;
 
-  static final double PERFORMANCE_THRESHOLD = 1.2;
+  static final double PERFORMANCE_THRESHOLD = 1.5;
   public static final int SIZE_50MB = 50_000_000;
 
   @Container

--- a/datavault-broker/src/test/java/org/datavaultplatform/common/storage/SFTPFileSystemPerformanceIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/common/storage/SFTPFileSystemPerformanceIT.java
@@ -153,7 +153,7 @@ public class SFTPFileSystemPerformanceIT {
 
     Progress progressStore = new Progress();
     long start1 = System.currentTimeMillis();
-    String storedPath = sftpFileSystemDriver.store(".", bigFile, progressStore);
+    String storedPath = sftpFileSystemDriver.store(".", bigFile, progressStore, "20240305142225");
     long diff1 = System.currentTimeMillis() - start1;
     ProgressInfo pInfoStore = new ProgressInfo("store", diff1, progressStore);
 

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/Device.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/Device.java
@@ -44,6 +44,10 @@ public abstract class Device {
     // Copy an object (file/dir) from the working space
     // Progress information should be updated for monitoring as the copy occurs
     public abstract String store(String path, File working, Progress progress) throws Exception;
+
+    public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
+        throw new UnsupportedOperationException();
+    }
     
     //public String store(String path, File working, Progress progress, String depositId) throws Exception {
     //		throw new UnsupportedOperationException();

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/Device.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/Device.java
@@ -45,9 +45,7 @@ public abstract class Device {
     // Progress information should be updated for monitoring as the copy occurs
     public abstract String store(String path, File working, Progress progress) throws Exception;
 
-    public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
-        throw new UnsupportedOperationException();
-    }
+    public abstract String store(String path, File working, Progress progress, String timeStampDirname) throws Exception;
     
     //public String store(String path, File working, Progress progress, String depositId) throws Exception {
     //		throw new UnsupportedOperationException();

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/Device.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/Device.java
@@ -43,9 +43,13 @@ public abstract class Device {
     }
     // Copy an object (file/dir) from the working space
     // Progress information should be updated for monitoring as the copy occurs
-    public abstract String store(String path, File working, Progress progress) throws Exception;
+    public String store(String path, File working, Progress progress) throws Exception {
+        throw new UnsupportedOperationException();
+    }
 
-    public abstract String store(String path, File working, Progress progress, String timeStampDirname) throws Exception;
+    public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
+        throw new UnsupportedOperationException();
+    }
     
     //public String store(String path, File working, Progress progress, String depositId) throws Exception {
     //		throw new UnsupportedOperationException();

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/SFTPFileSystemDriver.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/SFTPFileSystemDriver.java
@@ -31,6 +31,8 @@ public interface SFTPFileSystemDriver extends UserStore {
 
   String store(String path, File working, Progress progress) throws Exception;
 
+  String store(String path, File working, Progress progress, String timeStampDirName) throws Exception;
+
   boolean isMonitoring();
 
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/AmazonGlacier.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/AmazonGlacier.java
@@ -175,7 +175,12 @@ public class AmazonGlacier extends Device implements ArchiveStore {
         // Glacier generates a new ID which is required retrieve data.
         return archiveId;
     }
-    
+
+    @Override
+    public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
     @Override
     public Verify.Method getVerifyMethod() {
         return verificationMethod;

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/AmazonGlacier.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/AmazonGlacier.java
@@ -177,11 +177,6 @@ public class AmazonGlacier extends Device implements ArchiveStore {
     }
 
     @Override
-    public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Verify.Method getVerifyMethod() {
         return verificationMethod;
     }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/DropboxFileSystem.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/DropboxFileSystem.java
@@ -333,4 +333,9 @@ public class DropboxFileSystem extends Device implements UserStore {
         return path;*/
         return "";
     }
+
+    @Override
+    public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/DropboxFileSystem.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/DropboxFileSystem.java
@@ -333,9 +333,4 @@ public class DropboxFileSystem extends Device implements UserStore {
         return path;*/
         return "";
     }
-
-    @Override
-    public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/LocalFileSystem.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/LocalFileSystem.java
@@ -152,7 +152,12 @@ public class LocalFileSystem extends Device implements UserStore, ArchiveStore {
 
         return working.getName();
     }
-    
+
+    @Override
+    public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
     @Override
     public Verify.Method getVerifyMethod() {
         // Return the default verification method (copy back and check)

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/LocalFileSystem.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/LocalFileSystem.java
@@ -154,11 +154,6 @@ public class LocalFileSystem extends Device implements UserStore, ArchiveStore {
     }
 
     @Override
-    public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Verify.Method getVerifyMethod() {
         // Return the default verification method (copy back and check)
         return verificationMethod;

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/MultiLocalFileSystem.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/MultiLocalFileSystem.java
@@ -91,11 +91,6 @@ public class MultiLocalFileSystem extends Device implements ArchiveStore {
     }
 
     @Override
-    public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Verify.Method getVerifyMethod() {
         // Return the default verification method (copy back and check)
         return verificationMethod;

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/MultiLocalFileSystem.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/MultiLocalFileSystem.java
@@ -89,7 +89,12 @@ public class MultiLocalFileSystem extends Device implements ArchiveStore {
 
         return working.getName();
     }
-    
+
+    @Override
+    public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
     @Override
     public Verify.Method getVerifyMethod() {
         // Return the default verification method (copy back and check)

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/OracleObjectStorageClassic.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/OracleObjectStorageClassic.java
@@ -182,11 +182,6 @@ public class OracleObjectStorageClassic extends Device implements ArchiveStore {
 	}
 
 	@Override
-	public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void delete(String path, File working, Progress progress) {
 		/*try {
 			this.manager = FileTransferManager.getDefaultFileTransferManager(this.getTransferAuth());

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/OracleObjectStorageClassic.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/OracleObjectStorageClassic.java
@@ -180,7 +180,12 @@ public class OracleObjectStorageClassic extends Device implements ArchiveStore {
 		
 		return depositId;
 	}
-	
+
+	@Override
+	public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
+		throw new UnsupportedOperationException();
+	}
+
 	@Override
 	public void delete(String path, File working, Progress progress) {
 		/*try {

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/S3Cloud.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/S3Cloud.java
@@ -128,4 +128,9 @@ public class S3Cloud extends Device implements ArchiveStore {
 		return depositId;
 	}
 
+	@Override
+	public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
+		throw new UnsupportedOperationException();
+	}
+
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/S3Cloud.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/S3Cloud.java
@@ -128,9 +128,4 @@ public class S3Cloud extends Device implements ArchiveStore {
 		return depositId;
 	}
 
-	@Override
-	public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
-		throw new UnsupportedOperationException();
-	}
-
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemJSch.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemJSch.java
@@ -6,6 +6,7 @@ import java.nio.file.Paths;
 import java.time.Clock;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.util.encoders.Base64;
 import org.datavaultplatform.common.PropNames;
 import org.datavaultplatform.common.crypto.Encryption;
@@ -14,6 +15,7 @@ import org.datavaultplatform.common.model.FileInfo;
 import org.datavaultplatform.common.storage.Device;
 import org.datavaultplatform.common.storage.SFTPFileSystemDriver;
 import org.datavaultplatform.common.storage.impl.ssh.UtilityJSch;
+import org.springframework.util.Assert;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -346,7 +348,7 @@ public class SFTPFileSystemJSch extends Device implements SFTPFileSystemDriver {
 
     @Override
     public String store(String relativePath, File working, Progress progress, String timestampDirName) throws Exception {
-
+        Assert.isTrue(StringUtils.isNotBlank(timestampDirName), "The timestampDirName cannot be blank");
         String path = getFullPath(relativePath);
         try {
             Connect();

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemJSch.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemJSch.java
@@ -345,11 +345,6 @@ public class SFTPFileSystemJSch extends Device implements SFTPFileSystemDriver {
     }
 
     @Override
-    public String store(String path, File working, Progress progress) throws Exception {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public String store(String relativePath, File working, Progress progress, String timestampDirName) throws Exception {
 
         String path = getFullPath(relativePath);

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemJSch.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemJSch.java
@@ -359,7 +359,6 @@ public class SFTPFileSystemJSch extends Device implements SFTPFileSystemDriver {
             channelSftp.cd(path);
 
             // Create timestamped folder to avoid overwriting files
-            //String timestampDirName = SftpUtils.getTimestampedDirectoryName(clock);
             path = path + PATH_SEPARATOR + timestampDirName;
 
             mkdir(channelSftp, timestampDirName);

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemJSch.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemJSch.java
@@ -343,9 +343,14 @@ public class SFTPFileSystemJSch extends Device implements SFTPFileSystemDriver {
             Disconnect();
         }
     }
-    
+
     @Override
-    public String store(String relativePath, File working, Progress progress) throws Exception {
+    public String store(String path, File working, Progress progress) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String store(String relativePath, File working, Progress progress, String timestampDirName) throws Exception {
 
         String path = getFullPath(relativePath);
         try {
@@ -354,7 +359,7 @@ public class SFTPFileSystemJSch extends Device implements SFTPFileSystemDriver {
             channelSftp.cd(path);
 
             // Create timestamped folder to avoid overwriting files
-            String timestampDirName = SftpUtils.getTimestampedDirectoryName(clock);
+            //String timestampDirName = SftpUtils.getTimestampedDirectoryName(clock);
             path = path + PATH_SEPARATOR + timestampDirName;
 
             mkdir(channelSftp, timestampDirName);

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemSSHD.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemSSHD.java
@@ -170,11 +170,6 @@ public class SFTPFileSystemSSHD extends Device implements SFTPFileSystemDriver {
   }
 
   @Override
-  public String store(String path, File working, Progress progress) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public String store(String path, File localFileOrDirectory, Progress progress, String timestampDirName) throws Exception {
     try (SFTPConnection con = getConnection()) {
 

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemSSHD.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemSSHD.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sshd.sftp.client.SftpClient;
 import org.apache.sshd.sftp.client.SftpClient.Attributes;
 import org.apache.sshd.sftp.client.extensions.SpaceAvailableExtension;
@@ -25,6 +26,7 @@ import org.datavaultplatform.common.storage.Device;
 import org.datavaultplatform.common.storage.SFTPFileSystemDriver;
 import org.datavaultplatform.common.storage.impl.ssh.UtilitySSHD;
 import org.datavaultplatform.common.storage.impl.ssh.UtilitySSHD.SFTPMonitorSSHD;
+import org.springframework.util.Assert;
 
 /**
  * An implementation of SFTPFileSystemDriver to use Apache sshd's sftp-client library.
@@ -171,6 +173,7 @@ public class SFTPFileSystemSSHD extends Device implements SFTPFileSystemDriver {
 
   @Override
   public String store(String path, File localFileOrDirectory, Progress progress, String timestampDirName) throws Exception {
+    Assert.isTrue(StringUtils.isNotBlank(timestampDirName), "The timestampDirName cannot be blank");
     try (SFTPConnection con = getConnection()) {
 
       final Path basePath = Paths.get(con.getFullPath(path));

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemSSHD.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemSSHD.java
@@ -170,13 +170,18 @@ public class SFTPFileSystemSSHD extends Device implements SFTPFileSystemDriver {
   }
 
   @Override
-  public String store(String path, File localFileOrDirectory, Progress progress) throws Exception {
+  public String store(String path, File working, Progress progress) throws Exception {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String store(String path, File localFileOrDirectory, Progress progress, String timestampDirName) throws Exception {
     try (SFTPConnection con = getConnection()) {
 
       final Path basePath = Paths.get(con.getFullPath(path));
 
       // Create timestamped folder to avoid overwriting files
-      String timestampDirName = SftpUtils.getTimestampedDirectoryName(connectionInfo.getClock());
+      //String timestampDirName = SftpUtils.getTimestampedDirectoryName(connectionInfo.getClock());
       Path tsDirPath = basePath.resolve(timestampDirName);
 
       UtilitySSHD.createDir(con.sftpClient, tsDirPath);

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemSSHD.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/SFTPFileSystemSSHD.java
@@ -181,7 +181,6 @@ public class SFTPFileSystemSSHD extends Device implements SFTPFileSystemDriver {
       final Path basePath = Paths.get(con.getFullPath(path));
 
       // Create timestamped folder to avoid overwriting files
-      //String timestampDirName = SftpUtils.getTimestampedDirectoryName(connectionInfo.getClock());
       Path tsDirPath = basePath.resolve(timestampDirName);
 
       UtilitySSHD.createDir(con.sftpClient, tsDirPath);

--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
@@ -216,7 +216,12 @@ public class TivoliStorageManager extends Device implements ArchiveStore {
         }
         return depositId;
     }
-    
+
+	@Override
+	public String store(String path, File working, Progress progress, String timeStampDirname) throws Exception {
+		throw new UnsupportedOperationException();
+	}
+
 //    private String storeInTSMNode(File working, Progress progress, String optFilePath, String description) throws Exception {
 //
 //        // check we have enough space to store the data (is the file bagged and tarred atm or is the actual space going to be different?)

--- a/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/BasePerformDepositThenRetrieveIT.java
+++ b/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/BasePerformDepositThenRetrieveIT.java
@@ -247,6 +247,7 @@ public abstract class BasePerformDepositThenRetrieveIT extends BaseRabbitTCTest 
   @SneakyThrows
   private void checkRetrieve() {
     log.info("FIN {}", retrieveDir.getCanonicalPath());
+    log.info("FIN {}", retrieveDir.getCanonicalPath());
     waitUntil(this::foundRetrieveComplete);
     log.info("FIN {}", retrieveDir.getCanonicalPath());
     File retrieved = new File(this.retrieveDir + "/src-path-1/src-file-1");

--- a/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/BasePerformDepositThenRetrieveIT.java
+++ b/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/BasePerformDepositThenRetrieveIT.java
@@ -239,7 +239,7 @@ public abstract class BasePerformDepositThenRetrieveIT extends BaseRabbitTCTest 
   }
 
   void waitUntil(Callable<Boolean> test) {
-    Awaitility.await().atMost(5, TimeUnit.MINUTES)
+    Awaitility.await().atMost(15, TimeUnit.MINUTES)
         .pollInterval(Duration.ofSeconds(15))
         .until(test);
   }

--- a/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/BasePerformDepositThenRetrieveIT.java
+++ b/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/BasePerformDepositThenRetrieveIT.java
@@ -70,6 +70,7 @@ public abstract class BasePerformDepositThenRetrieveIT extends BaseRabbitTCTest 
   static final String KEY_NAME_FOR_SSH = "key-name-for-ssh";
   static final String KEY_NAME_FOR_DATA = "key-name-for-data";
   static final String KEY_STORE_PASSWORD = "testPassword";
+  public static final String DATA_VAULT_HIDDEN_FILE = ".datavault";
 
   final Resource depositMessage = new ClassPathResource("sampleMessages/sampleDepositMessage.json");
 
@@ -233,20 +234,21 @@ public abstract class BasePerformDepositThenRetrieveIT extends BaseRabbitTCTest 
 
     checkDepositWorkedOkay(depositMessage, depositEvents);
 
+    File hiddenFile = new File(this.retrieveDir, DATA_VAULT_HIDDEN_FILE);
+    assertThat(hiddenFile).doesNotExist();
     buildAndSendRetrieveMessage(depositEvents);
     checkRetrieve();
-
+    assertThat(hiddenFile).exists().isFile().isReadable();
   }
 
   void waitUntil(Callable<Boolean> test) {
-    Awaitility.await().atMost(15, TimeUnit.MINUTES)
+    Awaitility.await().atMost(5, TimeUnit.MINUTES)
         .pollInterval(Duration.ofSeconds(15))
         .until(test);
   }
 
   @SneakyThrows
   private void checkRetrieve() {
-    log.info("FIN {}", retrieveDir.getCanonicalPath());
     log.info("FIN {}", retrieveDir.getCanonicalPath());
     waitUntil(this::foundRetrieveComplete);
     log.info("FIN {}", retrieveDir.getCanonicalPath());

--- a/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/RetrieveTest.java
+++ b/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/RetrieveTest.java
@@ -1,26 +1,527 @@
 package org.datavaultplatform.worker.tasks;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.io.File;
 import lombok.SneakyThrows;
+import org.datavaultplatform.common.PropNames;
+import org.datavaultplatform.common.event.Event;
+import org.datavaultplatform.common.event.EventSender;
+import org.datavaultplatform.common.io.Progress;
+import org.datavaultplatform.common.model.ArchiveStore;
+import org.datavaultplatform.common.storage.Device;
+import org.datavaultplatform.common.storage.impl.LocalFileSystem;
+import org.datavaultplatform.common.storage.impl.SFTPFileSystemSSHD;
+import org.datavaultplatform.common.task.Context;
+import org.datavaultplatform.common.util.StorageClassNameResolver;
+import org.datavaultplatform.common.util.StorageClassUtils;
+import org.datavaultplatform.worker.test.TestClockConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class RetrieveTest {
 
-  @Test
-  @SneakyThrows
-  void testThrowCheckSumError() {
-    File mFile = mock(File.class);
-    when(mFile.getCanonicalPath()).thenReturn("/tmp/some/file.1.tar");
-    Exception ex = assertThrows(Exception.class, () -> Retrieve.throwChecksumError("<actualCS>", "<expectedCS>",
-        mFile, "test"));
-    assertEquals("Checksum failed:test:(actual)<actualCS> != (expected)<expectedCS>:/tmp/some/file.1.tar", ex.getMessage());
-  }
+    public static final String TEST_RETRIEVE_PATH = "retrieve-path";
+    public static final String TEST_TIMESTAMP_DIR_NAME = "dv_20220329141516";
+    private static final String TEST_ARCHIVE_ID = "test-archive-id";
+    @Mock
+    EventSender mEventSender;
+
+    @Mock
+    Context mContext;
+
+    @Captor
+    ArgumentCaptor<Event> argEvent;
+
+    @Mock
+    StorageClassNameResolver mStorageClassResolver;
+
+    @Mock
+    SFTPFileSystemSSHD mSftpUserStore;
+
+    @Mock
+    LocalFileSystem mNonSftpUserStore;
+
+    @Mock
+    LocalFileSystem mArchiveFS;
+
+    org.datavaultplatform.common.model.ArchiveStore storageModel;
+
+    @Captor
+    ArgumentCaptor<String> argTimestampDirName1;
+
+    @Captor
+    ArgumentCaptor<String> argTimestampDirName2;
+
+
+    @Captor
+    ArgumentCaptor<Context> argContext;
+
+    @Captor
+    ArgumentCaptor<String> argTarFileName;
+
+    @Captor
+    ArgumentCaptor<File> argTarFile;
+
+    @Captor
+    ArgumentCaptor<Device> argArchiveFs;
+
+    @Captor
+    ArgumentCaptor<Device> argUserStoreFs;
+
+
+    @BeforeEach
+    void setup() {
+        this.storageModel = new ArchiveStore();
+        this.storageModel.setStorageClass("ARCHIVE_STORE_STORAGE_CLASS_NAME");
+    }
+
+    @Test
+    @SneakyThrows
+    void testThrowCheckSumError() {
+        File mFile = mock(File.class);
+        when(mFile.getCanonicalPath()).thenReturn("/tmp/some/file.1.tar");
+        Exception ex = assertThrows(Exception.class, () -> Retrieve.throwChecksumError("<actualCS>", "<expectedCS>",
+                mFile, "test"));
+        assertEquals("Checksum failed:test:(actual)<actualCS> != (expected)<expectedCS>:/tmp/some/file.1.tar", ex.getMessage());
+    }
+
+    @Nested
+    class SftpUserStoreTests {
+
+        @BeforeEach
+        void setup() {
+            setupSftpUserStore();
+        }
+
+        @Test
+        void testSingleCopyStoreWhenUpfrontUserStoreWriteSucceeds() {
+            checkRetrieve(true, true, true);
+        }
+
+        @Test
+        void testMultipleCopiesWhenUpfrontUserStoreWriteSucceeds() {
+            checkRetrieve(true, false, true);
+        }
+
+        @Test
+        void testSingleCopyStoreWhenUpfrontUserStoreWriteFails() {
+            checkRetrieve(true, true, false);
+        }
+
+        @Test
+        void testMultipleCopiesWhenUpfrontUserStoreWriteFails() {
+            checkRetrieve(true, false, false);
+        }
+
+    }
+
+    @Nested
+    class NonSftpUserStoreTests {
+
+        @BeforeEach
+        void setup() {
+            setupNonSftpUserStore();
+        }
+
+        @Test
+        void testSingleCopyStoreWhenUpfrontUserStoreWriteSucceeds() {
+            checkRetrieve(false, true, true);
+        }
+
+        @Test
+        void testMultipleCopiesWhenUpfrontUserStoreWriteSucceeds() {
+            checkRetrieve(false, false, true);
+        }
+
+        @Test
+        void testSingleCopyStoreWhenUpfrontUserStoreWriteFails() {
+            checkRetrieve(false, true, false);
+        }
+
+        @Test
+        void testMultipleCopiesWhenUpfrontUserStoreWriteFails() {
+            checkRetrieve(false, false, false);
+        }
+
+    }
+
+    private Retrieve getRetrieveForTest(boolean singleCopy) {
+        lenient().when(mContext.getEventSender()).thenReturn(mEventSender);
+        lenient().when(mContext.getStorageClassNameResolver()).thenReturn(mStorageClassResolver);
+        lenient().when(mContext.getTempDir()).thenReturn(Paths.get("/tmp/dir"));
+
+        lenient().doNothing().when(mEventSender).send(argEvent.capture());
+        lenient().when(mArchiveFS.hasMultipleCopies()).thenReturn(!singleCopy);
+
+        Retrieve retrieve = Mockito.spy(new Retrieve());
+        retrieve.setArchiveIds(new String[]{TEST_ARCHIVE_ID});
+        Map<String, String> properties = new HashMap<>();
+
+        properties.put(PropNames.DEPOSIT_ID, "test-deposit-id");
+        properties.put(PropNames.DEPOSIT_CREATION_DATE, "13-mar-2024");
+        properties.put(PropNames.RETRIEVE_ID, "retrieve-id");
+        properties.put(PropNames.BAG_ID, "bag-id");
+        properties.put(PropNames.RETRIEVE_PATH, TEST_RETRIEVE_PATH);
+        properties.put(PropNames.ARCHIVE_ID, "archive-id");
+        properties.put(PropNames.USER_ID, "user-id");
+        properties.put(PropNames.ARCHIVE_DIGEST, "archive-digest");
+        properties.put(PropNames.ARCHIVE_DIGEST_ALGORITHM, "archive-digest-algorithm");
+        properties.put(PropNames.NUM_OF_CHUNKS, "1");
+        properties.put(PropNames.ARCHIVE_SIZE, "2112");
+        retrieve.setProperties(properties);
+
+        Map<String, String> userFileStoreClasses = new HashMap<>();
+        userFileStoreClasses.put("USER_FILE_STORE_1", "USER_FILE_STORE_1_CLASS");
+        retrieve.setUserFileStoreClasses(userFileStoreClasses);
+        Map<String, Map<String, String>> userFileStoreProperties = new HashMap<>();
+        userFileStoreProperties.put("USER_FILE_STORE_1", new HashMap<>());
+        retrieve.setUserFileStoreProperties(userFileStoreProperties);
+
+        retrieve.setArchiveFileStores(Collections.singletonList(storageModel));
+        return retrieve;
+    }
+
+    @SneakyThrows
+    void checkRetrieve(boolean useSftpUserStore, boolean singleCopy, boolean upfrontUserStoreWriteSucceeds) {
+
+        Retrieve retrieve = getRetrieveForTest(singleCopy);
+
+        // override the clock with a fixed clock for testing
+        lenient().when(retrieve.getClock()).thenReturn(TestClockConfig.TEST_CLOCK);
+        if (singleCopy) {
+            lenient().doNothing().when(retrieve).singleCopy(
+                    argContext.capture(),
+                    argTarFileName.capture(),
+                    argTarFile.capture(),
+                    argArchiveFs.capture(),
+                    argUserStoreFs.capture(),
+                    argTimestampDirName2.capture());
+        } else {
+            lenient().doNothing().when(retrieve).multipleCopies(
+                    argContext.capture(),
+                    argTarFileName.capture(),
+                    argTarFile.capture(),
+                    argArchiveFs.capture(),
+                    argUserStoreFs.capture(),
+                    argTimestampDirName2.capture());
+        }
+
+        try (MockedStatic<StorageClassUtils> storageClassUtilsStatic = Mockito.mockStatic(StorageClassUtils.class)) {
+
+            storageClassUtilsStatic.when(() -> StorageClassUtils.createStorage(any(), any(), any(), any())).thenAnswer(invocation -> {
+                String storageClassName = invocation.getArgument(0, String.class);
+                if (storageClassName.equals("USER_FILE_STORE_1_CLASS")) {
+                    if (useSftpUserStore) {
+                        return mSftpUserStore;
+                    } else {
+                        return mNonSftpUserStore;
+                    }
+                } else {
+                    return mArchiveFS;
+                }
+            });
+
+            if (useSftpUserStore) {
+                when(mSftpUserStore.getUsableSpace()).thenReturn(10_000L);
+                when(mSftpUserStore.exists(any())).thenReturn(true);
+                when(mSftpUserStore.isDirectory(any())).thenReturn(true);
+            } else {
+                when(mNonSftpUserStore.getUsableSpace()).thenReturn(10_000L);
+                when(mNonSftpUserStore.exists(any())).thenReturn(true);
+                when(mNonSftpUserStore.isDirectory(any())).thenReturn(true);
+
+            }
+
+            if (useSftpUserStore) {
+                if (upfrontUserStoreWriteSucceeds) {
+                    when(mSftpUserStore.store(any(), any(), any(), argTimestampDirName1.capture())).thenReturn("STORED");
+                } else {
+                    when(mSftpUserStore.store(any(), any(), any(), argTimestampDirName1.capture())).thenThrow(new RuntimeException("UserStoreFS : store failed"));
+                }
+            } else {
+                if (upfrontUserStoreWriteSucceeds) {
+                    when(mNonSftpUserStore.store(any(), any(), any())).thenReturn("STORED");
+                } else {
+                    when(mNonSftpUserStore.store(any(), any(), any())).thenThrow(new RuntimeException("UserStoreFS : store failed"));
+                }
+            }
+
+            try {
+                retrieve.performAction(mContext);
+            } catch (RuntimeException ex) {
+                if (upfrontUserStoreWriteSucceeds) {
+                    fail("unexpected exception");
+                } else {
+                    assertThat(ex).hasMessage("UserStoreFS : store failed");
+                }
+            }
+
+
+            if (useSftpUserStore) {
+                // Check that we always store the DataVault hidden file on the userstore regardless of singleCopy or multipleCopies
+                verify(mSftpUserStore).store(eq(TEST_RETRIEVE_PATH), eq(Retrieve.DATA_VAULT_HIDDEN_FILE), any(Progress.class), eq(TEST_TIMESTAMP_DIR_NAME));
+            } else {
+                verify(mNonSftpUserStore).store(eq(TEST_RETRIEVE_PATH), eq(Retrieve.DATA_VAULT_HIDDEN_FILE), any(Progress.class));
+            }
+
+            if (upfrontUserStoreWriteSucceeds) {
+
+                Context actualContext = argContext.getValue();
+                assertThat(actualContext).isEqualTo(mContext);
+
+                String actualTarFileName = argTarFileName.getValue();
+                assertThat(actualTarFileName).isEqualTo("bag-id.tar");
+
+                File actualTarFile = argTarFile.getValue();
+                assertThat(actualTarFile).isEqualTo(new File("/tmp/dir/bag-id.tar"));
+
+                Device actualArchiveFs = argArchiveFs.getValue();
+                assertThat(actualArchiveFs).isEqualTo(mArchiveFS);
+
+                Device actualUserStoreFs = argUserStoreFs.getValue();
+
+                if (useSftpUserStore) {
+                    assertThat(actualUserStoreFs).isEqualTo(mSftpUserStore);
+
+                    String actualTimestampDir1 = argTimestampDirName1.getValue();
+                    String actualTimestampDir2 = argTimestampDirName2.getValue();
+
+                    assertThat(actualTimestampDir1).isEqualTo(actualTimestampDir2);
+                    assertThat(actualTimestampDir1).isEqualTo(TEST_TIMESTAMP_DIR_NAME);
+                } else {
+                    assertThat(actualUserStoreFs).isEqualTo(mNonSftpUserStore);
+
+                }
+
+                if (singleCopy) {
+                    verify(retrieve).singleCopy(actualContext, actualTarFileName, actualTarFile, actualArchiveFs, actualUserStoreFs, TEST_TIMESTAMP_DIR_NAME);
+                } else {
+                    verify(retrieve).multipleCopies(actualContext, actualTarFileName, actualTarFile, actualArchiveFs, actualUserStoreFs, TEST_TIMESTAMP_DIR_NAME);
+                }
+
+                checkErrorMessages("Job states: 5", "Deposit retrieve started", "Job progress update");
+            } else {
+                verify(retrieve, never()).singleCopy(any(), any(), any(), any(), any(), any());
+                verify(retrieve, never()).multipleCopies(any(), any(), any(), any(), any(), any());
+
+                checkErrorMessages(
+                        "Job states: 5",
+                        "Deposit retrieve started",
+                        "Unable to perform test write of file[.datavault] to user space",
+                        "Data retrieve failed: UserStoreFS : store failed");
+            }
+        }
+    }
+
+    @Test
+    void testProblemWithUserStore() {
+        Retrieve retrieve = getRetrieveForTest(true);
+
+        try (MockedStatic<StorageClassUtils> storageClassUtilsStatic = Mockito.mockStatic(StorageClassUtils.class)) {
+
+            storageClassUtilsStatic.when(() -> StorageClassUtils.createStorage(any(), any(), any(), any())).thenAnswer(invocation -> {
+                String storageClassName = invocation.getArgument(0, String.class);
+                assertThat(storageClassName).isEqualTo("USER_FILE_STORE_1_CLASS");
+                throw new RuntimeException("problem creating UserStore");
+            });
+
+            try {
+                retrieve.performAction(mContext);
+                fail("exception expected!s");
+            } catch (RuntimeException ex) {
+                assertThat(ex).hasMessage("problem creating UserStore");
+            }
+
+            checkErrorMessages("Job states: 5",
+                    "Deposit retrieve started",
+                    "Retrieve failed: could not access user filesystem");
+        }
+    }
+
+    @Test
+    void testProblemWithArchiveStore() {
+        Retrieve retrieve = getRetrieveForTest(true);
+
+        try (MockedStatic<StorageClassUtils> storageClassUtilsStatic = Mockito.mockStatic(StorageClassUtils.class)) {
+
+            storageClassUtilsStatic.when(() -> StorageClassUtils.createStorage(any(), any(), any(), any())).thenAnswer(invocation -> {
+                String storageClassName = invocation.getArgument(0, String.class);
+                if (storageClassName.equals("USER_FILE_STORE_1_CLASS")) {
+                    return mSftpUserStore;
+                } else {
+                    throw new RuntimeException("problem creating ArchiveStore");
+                }
+            });
+
+            try {
+                retrieve.performAction(mContext);
+                fail("exception expected!");
+            } catch (RuntimeException ex) {
+                assertThat(ex).hasMessage("problem creating ArchiveStore");
+            }
+
+            checkErrorMessages("Job states: 5",
+                    "Deposit retrieve started",
+                    "Retrieve failed: could not access archive filesystem");
+        }
+    }
+
+    @Test
+    void testRedeliverTrue() {
+        Retrieve retrieve = getRetrieveForTest(true);
+        retrieve.setIsRedeliver(true);
+        retrieve.performAction(mContext);
+        checkErrorMessages("Retrieve stopped: the message had been redelivered, please investigate");
+    }
+
+    @Test
+    @SneakyThrows
+    void testNotEnoughSpaceOnUserStore() {
+        setupSftpUserStore();
+
+        Retrieve retrieve = getRetrieveForTest(true);
+
+        when(mSftpUserStore.getUsableSpace()).thenReturn(0L);
+
+        try (MockedStatic<StorageClassUtils> storageClassUtilsStatic = Mockito.mockStatic(StorageClassUtils.class)) {
+
+            storageClassUtilsStatic.when(() -> StorageClassUtils.createStorage(any(), any(), any(), any())).thenAnswer(invocation -> {
+                String storageClassName = invocation.getArgument(0, String.class);
+                if (storageClassName.equals("USER_FILE_STORE_1_CLASS")) {
+                    return mSftpUserStore;
+                } else {
+                    return mArchiveFS;
+                }
+            });
+
+            try {
+                retrieve.performAction(mContext);
+                fail("exception expected!");
+            } catch (RuntimeException ex) {
+                assertThat(ex).hasMessage("Not enough free space to retrieve data!");
+            }
+
+            checkErrorMessages("Job states: 5",
+                    "Deposit retrieve started",
+                    "Not enough free space to retrieve data!",
+                    "Data retrieve failed: Not enough free space to retrieve data!");
+        }
+    }
+    @Test
+    @SneakyThrows
+    void testProblemWithUserStoreGetUsableSpace() {
+
+        setupSftpUserStore();
+
+        Retrieve retrieve = getRetrieveForTest(true);
+
+        when(mSftpUserStore.getUsableSpace()).thenThrow(new Exception("problemGettingUsableSpace!"));
+
+        try (MockedStatic<StorageClassUtils> storageClassUtilsStatic = Mockito.mockStatic(StorageClassUtils.class)) {
+
+            storageClassUtilsStatic.when(() -> StorageClassUtils.createStorage(any(), any(), any(), any())).thenAnswer(invocation -> {
+                String storageClassName = invocation.getArgument(0, String.class);
+                if (storageClassName.equals("USER_FILE_STORE_1_CLASS")) {
+                    return mSftpUserStore;
+                } else {
+                    return mArchiveFS;
+                }
+            });
+
+            try {
+                retrieve.performAction(mContext);
+                fail("exception expected!");
+            } catch (RuntimeException ex) {
+                assertThat(ex).hasMessage("java.lang.Exception: problemGettingUsableSpace!");
+            }
+
+            checkErrorMessages("Job states: 5",
+                    "Deposit retrieve started",
+                    "Unable to determine free space",
+                    "Data retrieve failed: problemGettingUsableSpace!");
+        }
+    }
+
+
+    private void checkErrorMessages(String... expectedMessages) {
+        String[] actualMessages = argEvent.getAllValues().stream().map(Event::getMessage).toArray(String[]::new);
+        assertThat(actualMessages).isEqualTo(expectedMessages);
+    }
+
+    private void setupNonSftpUserStore() {
+        lenient().when(mNonSftpUserStore.exists(TEST_RETRIEVE_PATH)).thenReturn(true);
+        lenient().when(mNonSftpUserStore.isDirectory(TEST_RETRIEVE_PATH)).thenReturn(true);
+    }
+
+    @SneakyThrows
+    private void setupSftpUserStore() {
+        lenient().when(mSftpUserStore.exists(TEST_RETRIEVE_PATH)).thenReturn(true);
+        lenient().when(mSftpUserStore.isDirectory(TEST_RETRIEVE_PATH)).thenReturn(true);
+    }
+
+    @Nested
+    class RetrieveTargetErrorTests{
+
+        @Test
+        @SneakyThrows
+        void testRetrieveTargetDoesNotExist() {
+            when(mSftpUserStore.exists(TEST_RETRIEVE_PATH)).thenReturn(false);
+            checkTargetDirectoryError();
+            verify(mSftpUserStore).exists(TEST_RETRIEVE_PATH);
+            verify(mSftpUserStore, never()).isDirectory(TEST_RETRIEVE_PATH);
+        }
+
+        @Test
+        @SneakyThrows
+        void testRetrieveTargetIsNotADirectory() {
+            when(mSftpUserStore.exists(TEST_RETRIEVE_PATH)).thenReturn(true);
+            when(mSftpUserStore.isDirectory(TEST_RETRIEVE_PATH)).thenReturn(false);
+            checkTargetDirectoryError();
+            verify(mSftpUserStore).exists(TEST_RETRIEVE_PATH);
+            verify(mSftpUserStore).isDirectory(TEST_RETRIEVE_PATH);
+        }
+
+        void checkTargetDirectoryError() {
+            Retrieve retrieve = getRetrieveForTest(true);
+            try (MockedStatic<StorageClassUtils> storageClassUtilsStatic = Mockito.mockStatic(StorageClassUtils.class)) {
+                storageClassUtilsStatic.when(() -> StorageClassUtils.createStorage(any(), any(), any(), any())).thenAnswer(invocation -> {
+                    String storageClassName = invocation.getArgument(0, String.class);
+                    if (storageClassName.equals("USER_FILE_STORE_1_CLASS")) {
+                        return mSftpUserStore;
+                    } else {
+                        return mArchiveFS;
+                    }
+                });
+
+                try {
+                    retrieve.performAction(mContext);
+                    fail("exception expected!");
+                } catch (RuntimeException ex) {
+                    assertThat(ex).hasMessage("Target directory not found or is not a directory ! [retrieve-path]");
+                }
+
+                checkErrorMessages("Job states: 5",
+                        "Deposit retrieve started",
+                        "Target directory not found or is not a directory ! [retrieve-path]",
+                        "Data retrieve failed: Target directory not found or is not a directory ! [retrieve-path]"
+                );
+            }
+        }
+    }
+
 }
+
+

--- a/datavault-worker/src/test/java/org/datavaultplatform/worker/test/TestClockConfig.java
+++ b/datavault-worker/src/test/java/org/datavaultplatform/worker/test/TestClockConfig.java
@@ -11,12 +11,18 @@ import java.time.ZoneId;
 @TestConfiguration
 public class TestClockConfig {
 
+  public static final Clock TEST_CLOCK;
+
+  static {
+    TEST_CLOCK =  Clock.fixed(
+            Instant.parse("2022-03-29T13:15:16.101Z"),
+            ZoneId.of("Europe/London"));
+  }
+
   @Bean
   @Primary
   public Clock testClock() {
-    return Clock.fixed(
-        Instant.parse("2022-03-29T13:15:16.101Z"),
-        ZoneId.of("Europe/London"));
+    return TEST_CLOCK;
   }
 
 }


### PR DESCRIPTION
Backend fix to the issue where users can select a dir they don't have write permissions to when performing a retrieve.

Basically I've extended the checkFreeSpace method to also copy an empty file to the user space before doing anything else.

If it can't write it throws an error.

I did look at various ways of getting the permission from the sftp connection Google seemed to have varying opinions about whether that was either possible or reliable (mainly depending on platform)

All the tests pass on my machine which hopefully means that they pass on the build box too.

A couple of the test changes are to make size or speed params work on my local box we can revert those if folk like tbh I included those by mistake.

As usual we won't merge till things have been deployed / tested on demo but comments / feedback are fine :-)