### PR TITLE
LUC070-118 - Fix for bug that prevented Review Date change for vaults

### DIFF
--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminReviewsController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminReviewsController.java
@@ -130,7 +130,7 @@ public class AdminReviewsController {
 
         if ("Submit".equals(action)) {
             // Throw back an error if a new review date has not been entered but some deposits are being retained.
-            if (vaultReviewModel.getNewReviewDate() != null) {
+            if (vaultReviewModel.getNewReviewDate() == null) {
                 if (vaultReviewModel.getDepositReviewModels() != null) {
                     for (DepositReviewModel drm : vaultReviewModel.getDepositReviewModels()) {
                         if (drm.getDeleteStatus() == DepositReviewDeleteStatus.RETAIN) {


### PR DESCRIPTION
with retained deposits.
Change:
 - The check for null in Review Date is fixed if it has not been entered. The previous code in block then works as expected:

 if ("Submit".equals(action)) {
            // Throw back an error if a new review date has not been entered but some deposits are being retained.
            if (vaultReviewModel.getNewReviewDate() == null) { <------ FIXED LINE
                if (vaultReviewModel.getDepositReviewModels() != null) {
                    for (DepositReviewModel drm : vaultReviewModel.getDepositReviewModels()) {
                        if (drm.getDeleteStatus() == DepositReviewDeleteStatus.RETAIN) {
                            redirectAttributes.addAttribute("error", "reviewdate");
                            return "redirect:/admin/vaults/" + vaultID + "/reviews";
                        }
                    }
                }
            }
        }