### PR TITLE
update SFTP Driver from old jcraft JSch driver to new non-jcraft JSch Driver

### DIFF
--- a/datavault-broker/src/test/java/org/datavaultplatform/broker/services/UserKeyPairServiceOpenSSH8pt8IT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/broker/services/UserKeyPairServiceOpenSSH8pt8IT.java
@@ -5,8 +5,8 @@ import org.datavaultplatform.common.docker.DockerImage;
 import org.testcontainers.utility.DockerImageName;
 
 /**
- * This test that we CANNOT use an 'ssh-rsa' KeyPair get make an SSH/SFTP connection
- * to a server running OpenSSH 8.8
+ * This test that we CAN use an 'ssh-rsa' KeyPair get make an SSH/SFTP connection
+ * to a server running OpenSSH 8.8 when we use NEW (non-jcraft) JSCH !!!
  */
 @Slf4j
 public class UserKeyPairServiceOpenSSH8pt8IT extends BaseUserKeyPairServiceOpenSSHTest {
@@ -19,7 +19,7 @@ public class UserKeyPairServiceOpenSSH8pt8IT extends BaseUserKeyPairServiceOpenS
 
   @Override
   public boolean isSuccessExpected() {
-    return false;
+    return true;
   }
 
 }

--- a/datavault-broker/src/test/java/org/datavaultplatform/common/storage/BaseSFTPFileSystemUsernamePasswordIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/common/storage/BaseSFTPFileSystemUsernamePasswordIT.java
@@ -17,7 +17,7 @@ public abstract class BaseSFTPFileSystemUsernamePasswordIT extends BaseSFTPFileS
 
   static GenericContainer<?> initialiseContainer(String tcName) {
 
-    return new GenericContainer<>(DockerImage.OPEN_SSH_9pt0_IMAGE_NAME)
+    return new GenericContainer<>(DockerImage.OPEN_SSH_9pt7_IMAGE_NAME)
         .withEnv("TC_NAME", tcName)
         .withEnv(ENV_USER_NAME, TEST_USER)
         .withEnv(ENV_PASSWORD, TEST_PASSWORD)

--- a/datavault-common/pom.xml
+++ b/datavault-common/pom.xml
@@ -82,7 +82,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.jcraft</groupId>
+      <groupId>com.github.mwiede</groupId>
       <artifactId>jsch</artifactId>
     </dependency>
 

--- a/datavault-common/src/test/java/org/datavaultplatform/common/docker/DockerImage.java
+++ b/datavault-common/src/test/java/org/datavaultplatform/common/docker/DockerImage.java
@@ -20,10 +20,10 @@ public abstract class DockerImage {
   // https://hub.docker.com/r/linuxserver/openssh-server/tags
   public static final String OPEN_SSH_8pt6_IMAGE_NAME = "linuxserver/openssh-server:version-8.6_p1-r3";
 
-  //8.8 is when they removed sha-1 signature of ssh-rsa keys - causing problems with JSch
+  //8.8 is when they removed sha-1 signature of ssh-rsa keys - causing problems with 'OLD' (jcraft) JSch 0.1.55 Sftp Driver
   public static final String OPEN_SSH_8pt8_IMAGE_NAME = "linuxserver/openssh-server:version-8.8_p1-r1";
 
-  public static final String OPEN_SSH_9pt0_IMAGE_NAME = "linuxserver/openssh-server:version-9.0_p1-r2";
+  public static final String OPEN_SSH_9pt7_IMAGE_NAME = "linuxserver/openssh-server:version-9.7_p1-r4";
 
   public static final String OPEN_SSH_IMAGE_NAME = OPEN_SSH_8pt8_IMAGE_NAME;
   public static final DockerImageName OPEN_SSH_IMAGE = parse(OPEN_SSH_IMAGE_NAME);

--- a/pom.xml
+++ b/pom.xml
@@ -138,8 +138,8 @@
     <!-- https://mvnrepository.com/artifact/net.sf.supercsv/super-csv -->
     <super.csv.version>2.4.0</super.csv.version>
 
-    <!-- https://mvnrepository.com/artifact/com.jcraft/jsch -->
-    <jcraft.jsch.version>0.1.55</jcraft.jsch.version>
+    <!-- https://mvnrepository.com/artifact/com.github.mwiede/jsch -->
+    <jsch.version>0.2.18</jsch.version>
 
     <!-- https://mvnrepository.com/artifact/gov.loc/bagit -->
     <bagit.version>5.2.0</bagit.version>
@@ -284,9 +284,9 @@
         <version>${apache.directory.api.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.jcraft</groupId>
+        <groupId>com.github.mwiede</groupId>
         <artifactId>jsch</artifactId>
-        <version>${jcraft.jsch.version}</version>
+        <version>${jsch.version}</version>
       </dependency>
       <dependency>
         <groupId>net.sf.supercsv</groupId>


### PR DESCRIPTION
The old jcraft JSch Driver does not work with up-to-date SFTP Servers.

There is now an updated, drop-in replacement Sch driver (from a different team).
OLD https://mvnrepository.com/artifact/com.jcraft/jsch
NEW https://mvnrepository.com/artifact/com.github.mwiede/jsch

All our integration tests pass with new JSch driver.

IF we deploy this PR but get SFTP problems with DataStore - then I suspect DataStore SFTP Server needs updating.

when we looked on the 18th April 2024....
datastore is using SSH-2.0-OpenSSH_7.4
which is Dec 2016 vintage SSH
https://www.openssh.com/txt/release-7.4
