### PR TITLE
#LUC070-119 webapp controller method and GUI button to restart a failed retrieve

### DIFF
--- a/datavault-broker/pom.xml
+++ b/datavault-broker/pom.xml
@@ -149,7 +149,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/config/RabbitConfig.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/config/RabbitConfig.java
@@ -2,9 +2,11 @@ package org.datavaultplatform.broker.config;
 
 import lombok.extern.slf4j.Slf4j;
 import org.datavaultplatform.broker.queue.EventListener;
+import org.datavaultplatform.broker.queue.MessageIdProcessedListener;
 import org.datavaultplatform.broker.queue.TaskTimerSupport;
 import org.datavaultplatform.broker.queue.Sender;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
@@ -13,4 +15,10 @@ import org.springframework.context.annotation.Import;
 @Import({QueueConfig.class, Sender.class, TaskTimerSupport.class, EventListener.class, RabbitLocalConfig.class})
 @Slf4j
 public class RabbitConfig {
+    
+    
+    @Bean
+    MessageIdProcessedListener messageIdProcessedListener(){
+        return new MessageIdProcessedListener();
+    }
 }

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/DepositsController.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/DepositsController.java
@@ -253,6 +253,7 @@ public class DepositsController {
                                    @PathVariable("depositId") String depositId,
                                    @PathVariable("retrieveId") String retrieveId) throws Exception {
         User user = getUser(userID);
+        //User user = adminService.ensureAdminUser(userID);
         Deposit deposit = getUserDeposit(user, depositId);
         Retrieve retrieve = getRetrieve(retrieveId);   
         boolean retrieveMatchesDeposit = retrieve.getDeposit().equals(deposit);
@@ -269,8 +270,6 @@ public class DepositsController {
         if (lastEvent == null) {
             retrieve.setUser(user);
             checkForInProgressJob(deposit.getJobs());
-        } else {
-            Assert.isTrue(retrieve.getUser().equals(user),"The user does not match the retrieve user");
         }
 
         StorageIdAndRetrievePath storageIdAndRetrievePath = StorageIdAndRetrievePath.fromFullPath(retrieve.getRetrievePath());

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/queue/MessageIdProcessedListener.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/queue/MessageIdProcessedListener.java
@@ -1,0 +1,10 @@
+package org.datavaultplatform.broker.queue;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MessageIdProcessedListener {
+    public void processedMessageId(String messageId) {
+        log.debug("Processed Message Id: [{}]", messageId);
+    }
+}

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/DepositsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/DepositsService.java
@@ -110,6 +110,16 @@ public class DepositsService {
     public Deposit getDeposit(String depositID) {
         return depositDAO.findById(depositID).orElse(null);
     }
+
+    public Deposit getDepositForRetrieves(String depositID) {
+        Deposit deposit =  getDeposit(depositID);
+        if (deposit != null) {
+            deposit.getJobs().forEach(job -> job.getID());
+            deposit.getDepositChunks().forEach(dc -> dc.getID());
+            deposit.getArchives().forEach(arc -> arc.getId());
+        }
+        return deposit;
+    }
     
     public int count(String userId) { return depositDAO.count(userId, null); }
 
@@ -292,6 +302,26 @@ public class DepositsService {
         return eventDAO.findLatestRetrieveEvent(depositId, retrieveId)
                 .map(Event::refreshIdFields)
                 .orElse(null);
+    }
+
+    public String getDepositArchive(String depositId, ArchiveStore archiveStore) throws Exception {
+        Deposit deposit = getDeposit(depositId);
+        String archiveID = null;
+        if (deposit.getArchives() != null) {
+            for (Archive archive : deposit.getArchives()) {
+                if( archive != null && 
+                    archive.getArchiveStore() != null && 
+                    archive.getArchiveStore().getID().equals(archiveStore.getID())) {
+                    archiveID = archive.getArchiveId();
+                }
+            }
+        }
+
+        // Worth checking that we found a matching Archive for the ArchiveStore.
+        if (archiveID == null) {
+            throw new Exception("No valid archive for retrieval");
+        }
+        return archiveID;
     }
 }
 

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/EventService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/EventService.java
@@ -41,5 +41,9 @@ public class EventService {
     public List<Event> findVaultEvents(Vault vault) {
         return eventDAO.findVaultEvents(vault);
     }
+
+    public Event findById(String id) {
+        return eventDAO.findById(id).orElse(null);
+    }
 }
 

--- a/datavault-broker/src/test/java/org/datavaultplatform/broker/controllers/DepositControllerIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/broker/controllers/DepositControllerIT.java
@@ -7,6 +7,7 @@ import org.datavaultplatform.broker.services.*;
 import org.datavaultplatform.broker.test.AddTestProperties;
 import org.datavaultplatform.broker.test.BaseDatabaseTest;
 import org.datavaultplatform.common.event.Event;
+import org.datavaultplatform.common.event.retrieve.RetrieveStart;
 import org.datavaultplatform.common.model.*;
 import org.datavaultplatform.common.model.dao.DepositDAO;
 import org.datavaultplatform.common.model.dao.RetrieveDAO;
@@ -14,6 +15,8 @@ import org.datavaultplatform.common.model.dao.UserDAO;
 import org.datavaultplatform.common.model.dao.VaultDAO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -46,6 +49,8 @@ import static org.mockito.Mockito.*;
 @AutoConfigureMockMvc
 class DepositControllerIT extends BaseDatabaseTest {
 
+    public static final String NON_RESTART_JOB_ID = "testNonRestartJobId";
+    
     @MockBean
     EmailService emailService;
     
@@ -72,13 +77,27 @@ class DepositControllerIT extends BaseDatabaseTest {
     
     Deposit deposit2;
     
+    Job retrieveJob;
+    
     Vault vault;
     
     Retrieve retrieve1;
     @Autowired
     private UsersService usersService;
+    @Autowired
+    private EventService eventService;
+    
+    @Autowired
+    JobsService jobsService;
+    
+    @Autowired
+    DepositsService depositsService;
+    
+    @Captor
+    ArgumentCaptor<Event> argLastEvent;
 
-
+    RetrieveStart retrieveStart;
+    
     @BeforeEach
     void setup() {
         
@@ -100,12 +119,19 @@ class DepositControllerIT extends BaseDatabaseTest {
         deposit1.setHasPersonalData(false);
         deposit1.setName("deposit1");
         deposit1.setVault(vault);
+        deposit1.setNonRestartJobId(NON_RESTART_JOB_ID);
         depositDAO.save(deposit1);
+        
+        retrieveJob = new Job(Job.TASK_CLASS_RETRIEVE);
+        jobsService.addJob(deposit1, retrieveJob);
+        assertThat(retrieveJob).isNotNull();
 
         deposit2 = new Deposit();
         deposit2.setHasPersonalData(false);
         deposit2.setName("deposit2");
         deposit2.setVault(vault);
+        deposit2.setNonRestartJobId(NON_RESTART_JOB_ID);
+
         depositDAO.save(deposit2);
         
         retrieve1 = new Retrieve();
@@ -115,23 +141,40 @@ class DepositControllerIT extends BaseDatabaseTest {
         retrieveDAO.save(retrieve1);
         
         controllerSpy = spy(controller);
+
+        retrieveStart = new RetrieveStart();
+        retrieveStart.setDeposit(deposit1);
+        retrieveStart.setRetrieveId(retrieve1.getID());
+        retrieveStart.setJob(retrieveJob);
+        
+        eventService.addEvent(retrieveStart);
+        
+        Event byID = eventService.findById(retrieveStart.getID());
+        assertThat(byID.getID()).isEqualTo(retrieveStart.getID());
         
         User found = userDAO.findById(user1.getID()).get();
         assertThat(found).isEqualTo(user1);
 
         User found2 = usersService.getUser(user1.getID());
         assertThat(found2).isEqualTo(user1);
+        
+        Event lastEvent = depositsService.getLastNotFailedRetrieveEvent(deposit1.getID(), retrieve1.getID());
+        assertThat(lastEvent).isNotNull();
     }
     
     @Test
     @Transactional
-    void testRestartRetrieveWhereDepositAndRetrieveMatches() throws Exception{
-        doReturn(true).when(controllerSpy).runRetrieveDeposit(user1, deposit1, retrieve1, null);
+    void testRestartRetrieveWhereDepositAndRetrieveMatches() throws Exception {
+        
+        doReturn(true).when(controllerSpy).runRetrieveDeposit(eq(user1), eq(deposit1), eq(retrieve1), argLastEvent.capture());
         
         boolean result = controllerSpy.retrieveDepositRestart(user1.getID(), deposit1.getID(), retrieve1.getID());
         assertThat(result).isTrue();
-        
-        verify(controllerSpy).runRetrieveDeposit(user1, deposit1, retrieve1, null);
+
+        Event actualLastEvent = argLastEvent.getValue();
+        assertThat(actualLastEvent.getID()).isEqualTo(this.retrieveStart.getID());
+
+        verify(controllerSpy).runRetrieveDeposit(user1, deposit1, retrieve1, actualLastEvent);
     }
 
     @Test

--- a/datavault-broker/src/test/java/org/datavaultplatform/broker/controllers/DepositsControllerTest.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/broker/controllers/DepositsControllerTest.java
@@ -514,9 +514,7 @@ public class DepositsControllerTest {
         
         void checkRunDeposit(Event lastEvent, String expectedJson) throws Exception {
 
-            if (lastEvent != null) {
-                when(mRetrieve.getUser()).thenReturn(mUser);
-            } else {
+            if (lastEvent == null) {
                 doNothing().when(mDeposit).setNonRestartJobId(NEW_JOB_ID);
             }
             doReturn(NEW_JOB_ID).when(mDeposit).getNonRestartJobId();
@@ -607,7 +605,7 @@ public class DepositsControllerTest {
             if(lastEvent == null) {
                 verify(mRetrieve).setUser(mUser);
             }
-            verify(mRetrieve).getRetrievePath();
+            verify(mRetrieve, atLeast(1)).getRetrievePath();
 
             verify(mUser).getID();
             verify(mUser).getFileStores();

--- a/datavault-broker/src/test/java/org/datavaultplatform/broker/controllers/RetrieveRestartIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/broker/controllers/RetrieveRestartIT.java
@@ -1,0 +1,523 @@
+package org.datavaultplatform.broker.controllers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.datavaultplatform.broker.app.DataVaultBrokerApp;
+import org.datavaultplatform.broker.email.EmailBodyGenerator;
+import org.datavaultplatform.broker.queue.MessageIdProcessedListener;
+import org.datavaultplatform.broker.services.*;
+import org.datavaultplatform.broker.test.AddTestProperties;
+import org.datavaultplatform.broker.test.BaseDatabaseTest;
+import org.datavaultplatform.common.PropNames;
+import org.datavaultplatform.common.config.BaseQueueConfig;
+import org.datavaultplatform.common.docker.DockerImage;
+import org.datavaultplatform.common.event.Error;
+import org.datavaultplatform.common.event.Event;
+import org.datavaultplatform.common.event.InitStates;
+import org.datavaultplatform.common.event.UpdateProgress;
+import org.datavaultplatform.common.event.deposit.*;
+import org.datavaultplatform.common.event.retrieve.RetrieveStart;
+import org.datavaultplatform.common.model.*;
+import org.datavaultplatform.common.model.dao.JobDAO;
+import org.datavaultplatform.common.request.CreateDeposit;
+import org.datavaultplatform.common.response.DepositInfo;
+import org.datavaultplatform.common.storage.impl.LocalFileSystem;
+import org.datavaultplatform.common.task.Task;
+import org.datavaultplatform.common.util.TestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.core.QueueInformation;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+@Sql(scripts = "classpath:db/retrieveRestart.sql")
+@SpringBootTest(classes = DataVaultBrokerApp.class)
+@AddTestProperties
+@Slf4j
+@TestPropertySource(properties = {
+        "logging.level.org.springframework.security=TRACE",
+        "broker.security.enabled=true",
+        "broker.scheduled.enabled=false",
+        "broker.controllers.enabled=true",
+        "broker.services.enabled=true",
+        "broker.rabbit.enabled=true",
+        "broker.ldap.enabled=false",
+        "broker.initialise.enabled=false",
+        "broker.email.enabled=false",
+        "broker.database.enabled=true"})
+
+class RetrieveRestartIT extends BaseDatabaseTest {
+
+    private static final String ADMIN_USER_ID = "admin1";
+    
+    @Autowired
+    ArchivesService archivesService;
+    
+    @Autowired
+    RetentionPoliciesService rpService;
+    
+    @Autowired
+    DepositsController depositsController;
+    
+    @MockBean
+    JavaMailSender mailSender;
+
+    @Autowired
+    DepositsService depositsService;
+    
+    @Autowired
+    ArchiveStoreService archiveStoreService;
+    
+    @Autowired
+    UsersService usersService;
+
+    @Autowired
+    VaultsService vaultsService;
+
+    @Autowired
+    GroupsService groupsService;
+
+    @MockBean
+    EmailBodyGenerator emailBodyGenerator;
+    
+    @Autowired
+    JobsService jobsService;
+    
+    @Autowired
+    FileStoreService fileStoreService;
+    
+    @Autowired
+    JobDAO jobDAO;
+    
+    @Autowired
+    ObjectMapper mapper;
+    
+    @Container
+    @ServiceConnection
+    private static final RabbitMQContainer RABBIT = new RabbitMQContainer(DockerImage.RABBIT_IMAGE_NAME)
+            .withExposedPorts(5672,15672);
+
+    @PostConstruct
+    void init() {
+        log.info("RABBIT HTTP URL [ {} ]",RABBIT.getHttpUrl());
+    }
+
+    @Value(BaseQueueConfig.WORKER_QUEUE_NAME)
+    String queueNameToWorker;
+
+    @Value(BaseQueueConfig.BROKER_QUEUE_NAME)
+    String queueNameToBroker;
+
+    @Value(BaseQueueConfig.RESTART_WORKER_ONE_QUEUE_NAME)
+    String queueNameWorker1Restart;
+    @Value(BaseQueueConfig.RESTART_WORKER_TWO_QUEUE_NAME)
+    String queueNameWorker2Restart;
+    @Value(BaseQueueConfig.RESTART_WORKER_THREE_QUEUE_NAME)
+    String queueNameWorker3Restart;
+
+    @Autowired
+    AmqpAdmin amqpAdmin;
+    
+    @Autowired
+    RabbitTemplate rabbitTemplate;
+    
+    @MockBean
+    MessageIdProcessedListener mMessageIdProcessedListener;
+    
+    List<String> processedMessageIds;
+    
+    protected org.datavaultplatform.common.model.ArchiveStore archiveStore;
+    
+    @BeforeEach
+    void setup() {
+        QueueInformation qInfoToWorker = amqpAdmin.getQueueInfo(queueNameToWorker);
+        log.info("TO WORKER [{}]", qInfoToWorker);
+        
+        QueueInformation qInfoToBroker = amqpAdmin.getQueueInfo(queueNameToBroker);
+        log.info("TO BROKER [{}]", qInfoToBroker);
+        
+        processedMessageIds = new ArrayList<>();
+        Mockito.doAnswer(invocation -> {
+            String messageId = invocation.getArgument(0, String.class);
+            processedMessageIds.add(messageId);
+            return null;
+        }).when(mMessageIdProcessedListener).processedMessageId(any(String.class));
+
+        archiveStore = archiveStoreService.getForRetrieval();
+        assertThat(archiveStore.getID()).isEqualTo("test-lfs-id");
+        assertThat(archiveStore.getLabel()).isEqualTo("test-lfs-label");
+        assertThat(archiveStore.getStorageClass()).isEqualTo(LocalFileSystem.class.getName());
+        assertThat(archiveStore.isRetrieveEnabled()).isEqualTo(true);
+        assertThat(archiveStore.getProperties()).isEmpty();
+    }
+    
+    @Test
+    @SneakyThrows
+    void testRetrieveRestart() {
+        
+        List<RetentionPolicy> rps = rpService.getRetentionPolicies();
+        Collections.sort(rps, Comparator.comparing(RetentionPolicy::getID));
+        long initialRetentionPolicies = rps.size();
+        
+        long initialDepositsCount = depositsService.count(ADMIN_USER_ID);
+        long initialUserCount = usersService.getUsers().size();
+        long initialVaultCount = vaultsService.getVaults().size();
+        long initialGroupCount = groupsService.getGroups().size();
+        long initialArchivesCount = archivesService.getArchives().size();
+        
+        Group group1 = groupsService.getGroups().get(0);
+        
+        System.out.printf("existing deposits [%s]%n", initialDepositsCount);
+        System.out.printf("existing users [%s]%n", initialUserCount);
+        System.out.printf("existing vaults [%s]%n", initialVaultCount);
+        System.out.printf("existing retention policies [%s]%n", initialRetentionPolicies);
+        System.out.printf("existing groups [%s]%n", initialGroupCount);
+        System.out.printf("existing archives [%s]%n", initialArchivesCount);
+
+        assertThat(initialDepositsCount).isZero();
+        assertThat(initialUserCount).isEqualTo(2);
+        assertThat(initialVaultCount).isEqualTo(0);
+        assertThat(initialArchivesCount).isEqualTo(0);
+        
+        List<String> userids = usersService.getUsers().stream().map(User::getID).sorted().toList();
+        assertThat(userids).isEqualTo(List.of(ADMIN_USER_ID,"user1"));
+
+        User adminUser = usersService.getUser(ADMIN_USER_ID);
+
+        HashMap<String, String> props = new HashMap<>();
+        props.put(PropNames.ROOT_PATH, "/tmp");
+        FileStore fileStore1 = new FileStore(LocalFileSystem.class.getName(), props,"UFS1");
+        fileStore1.setUser(adminUser);
+        fileStoreService.addFileStore(fileStore1);
+
+        Vault vault = new Vault();
+        vault.setReviewDate(new Date());
+        vault.setRetentionPolicyStatus(123);
+        vault.setName("test vault");
+        vault.setDescription("test vault description");
+        vault.setCreationTime(new Date());
+        vault.setContact("Vault Owner");
+        vault.setRetentionPolicy(rps.get(0));
+        vault.setGroup(group1);
+
+        vaultsService.addVault(vault);
+        
+        String vaultId = vault.getID();
+        
+        CreateDeposit createDeposit = new CreateDeposit();
+        createDeposit.setVaultID(vaultId);
+        createDeposit.setName("test deposit");
+        createDeposit.setDescription("test deposit description");
+        createDeposit.setHasPersonalData("nope");
+        createDeposit.setFileUploadHandle("fileUploadHandle");
+        createDeposit.setPersonalDataStatement("personal data statement");
+        
+        ResponseEntity<DepositInfo> response1 = depositsController.addDeposit(ADMIN_USER_ID, createDeposit);
+        DepositInfo depositInfo = response1.getBody();
+        
+        String depositID = depositInfo.getID();
+        
+        Deposit deposit = depositsService.getDepositForRetrieves(depositID);
+        String bagId = deposit.getBagId();
+        assertThat(bagId).isNotBlank();
+
+        archivesService.addArchive(deposit, archiveStore, "AS1");
+        
+        Deposit deposit2 = depositsService.getDepositForRetrieves(depositID);
+
+        // SEND DEPOSITS EVENTS AND PROCESS THEM
+        sendDepositEventsFromBroker(deposit.getID());
+        
+        
+        // 1st RETRIEVE (a non-restart)
+
+        Retrieve retrieve = new Retrieve();
+        retrieve.setStatus(Retrieve.Status.NOT_STARTED);
+        retrieve.setUser(adminUser);
+        retrieve.setNote("test note");
+        retrieve.setRetrievePath(fileStore1.getID()+"/A/B/C");
+        retrieve.setHasExternalRecipients(false);
+        retrieve.setTimestamp(new Date());
+        retrieve.setDeposit(deposit2);
+
+        boolean result = depositsController.retrieveDeposit(ADMIN_USER_ID, depositID, retrieve);
+        assertThat(result).isTrue();
+        
+        Message depositMessage = rabbitTemplate.receive(this.queueNameToWorker);
+        String depositMessageJson = toPrettyJson(toString(depositMessage));
+        log.info("deposit message {}", depositMessageJson);
+
+        
+        Message retrieveMessage = rabbitTemplate.receive(this.queueNameToWorker);
+        String retrieveMessageJson = toPrettyJson(toString(retrieveMessage));
+        log.info("initial retrieve message {}", retrieveMessageJson);
+        
+        Task retrieveTask = mapper.readValue(retrieveMessageJson, Task.class);
+        assertThat(retrieveTask.getLastEvent()).isNull();
+        
+        // simiulate Worker sending a couple of events back to Broker
+        
+        Job latestJobForDeposit = jobDAO.findByDepositIdOrderByTimestampDesc(depositID).get(0);
+        
+        InitStates retrieveInitStates = new InitStates();
+        retrieveInitStates.setRetrieveId(retrieve.getID());
+        retrieveInitStates.setDepositId(deposit.getID());
+        retrieveInitStates.setUserId(deposit.getUser().getID());
+        retrieveInitStates.setJobId(latestJobForDeposit.getID());
+        
+        ArrayList<String> retrieveStates = new ArrayList<>();
+        retrieveStates.addAll(List.of("Computing free space",
+                "Retrieving from archive",
+                "Validating data",
+                "Transferring files",
+                "Data retrieve complete"));
+        retrieveInitStates.setStates(retrieveStates);
+        
+        String retrieveInitStatesId = sendBrokerEvent(retrieveInitStates);
+        
+        TestUtils.waitUntil(() -> processedMessageIds.contains(retrieveInitStatesId));
+
+        RetrieveStart retrieveStart = new RetrieveStart();
+        retrieveStart.setRetrieveId(retrieve.getID());
+        retrieveStart.setDepositId(deposit.getID());
+        retrieveStart.setUserId(deposit.getUser().getID());
+        retrieveStart.setJobId(latestJobForDeposit.getID());
+
+        String retrieveStartId = sendBrokerEvent(retrieveStart);
+        TestUtils.waitUntil(() -> processedMessageIds.contains(retrieveStartId));
+
+        Error error = new Error();
+        error.setDepositId(deposit.getID());
+        error.setRetrieveId(retrieve.getID());
+        error.setUserId(deposit.getUser().getID());
+        error.setJobId(latestJobForDeposit.getID());
+        
+        String errorId = sendBrokerEvent(error);
+        TestUtils.waitUntil(() -> processedMessageIds.contains(errorId));
+
+        // 2nd RETRIEVE (a restart)
+
+        String retrieveId = retrieve.getID();
+
+        assertThat(rabbitTemplate.getUnconfirmedCount()).isEqualTo(0);
+
+        depositsController.retrieveRestart(retrieveId);
+
+        Callable<Boolean> threeRestarts = () -> Stream.of(queueNameWorker1Restart, queueNameWorker2Restart, queueNameWorker3Restart)
+                .map(amqpAdmin::getQueueInfo)
+                .map(info -> info.getMessageCount() == 1)
+                .allMatch(Boolean::valueOf);
+        
+        TestUtils.waitUntil(threeRestarts);
+
+        Message retrieveRestartMessage = rabbitTemplate.receive(this.queueNameWorker1Restart);
+        String retrieveRestartMessageJson = toPrettyJson(toString(retrieveRestartMessage));
+        log.info("restart retrieve message {}", retrieveRestartMessageJson);
+        
+        // the original retrieve and the restart retrive are different
+        JSONAssert.assertNotEquals(retrieveMessageJson, retrieveRestartMessageJson, false);
+        
+        Task origRetrieveTask = mapper.readValue(retrieveMessageJson, Task.class);
+        Task restartRetrieveTask = mapper.readValue(retrieveRestartMessageJson, Task.class);
+        
+        // the original retrieve has no lastEvent
+        assertThat(origRetrieveTask.getLastEvent()).isNull();
+        
+        // the original retrieve the jobId is the same as the nonRestartJobId
+        assertThat(origRetrieveTask.getJobID()).isEqualTo(getNonRestartJobId(origRetrieveTask));
+
+        // the restart has a 'last event'
+        assertThat(restartRetrieveTask.getLastEvent()).isNotNull();
+        
+        // the restart nonRestartJobId is the same as the jobId in the original retrieve message
+        assertThat(origRetrieveTask.getJobID()).isEqualTo(getNonRestartJobId(restartRetrieveTask));
+
+        // if we make 2 changes to the origRetrieveTask structure
+        origRetrieveTask.setLastEvent(restartRetrieveTask.getLastEvent());
+        origRetrieveTask.setJobID(restartRetrieveTask.getJobID());
+        
+        // and write back to json to create 'retrieveRestartMessageJson2'
+        String retrieveRestartMessageJson2 = mapper.writeValueAsString(origRetrieveTask);
+        
+        // we should see the 'retrieveRestartMessageJson2' is the same as 'retrieveRestartMessageJson'
+        JSONAssert.assertEquals(retrieveRestartMessageJson, retrieveRestartMessageJson2, true);
+    }
+    
+    private String getNonRestartJobId(Task task){
+        return task.getProperties().get(PropNames.NON_RESTART_JOB_ID);
+    }
+
+    private void sendDepositEventsFromBroker(String depositId) {
+        Deposit deposit = depositsService.getDeposit(depositId);
+        String bagId = deposit.getBagId();
+        HashMap archiveIdsHashMap = new HashMap();
+        archiveIdsHashMap.put("AS1", bagId+".tar");
+
+        InitStates event1 = createEvent(InitStates.class, deposit);
+        event1.setStates(new ArrayList<>(List.of("Calculating size",
+                "Transferring",
+                "Packaging",
+                "Storing in archive",
+                "Verifying",
+                "Complete")));
+
+        Start event2 = createEvent(Start.class, deposit);
+        event2.withNextState(0);
+
+        ComputedSize event3 = createEvent(ComputedSize.class, deposit);
+        event3.setBytes(50_000);
+
+        UpdateProgress event4 = createEvent(UpdateProgress.class, deposit);
+        event4.withNextState(1);
+
+        UpdateProgress event5 = createEvent(UpdateProgress.class, deposit);
+        UpdateProgress event6 = createEvent(UpdateProgress.class, deposit);
+
+        TransferComplete event7 = createEvent(TransferComplete.class, deposit);
+        event7.withNextState(2);
+
+        PackageComplete event8 = createEvent(PackageComplete.class, deposit);
+        event8.withNextState(3);
+
+        ComputedDigest event9 = createEvent(ComputedDigest.class, deposit);
+        event9.setDigest("E11D93E31DDB4912C080C796B7FADF5C3574AFFC");
+        event9.setDigestAlgorithm("SHA-1");
+
+        HashMap<Integer,byte[]> chunksIVs = new HashMap<>();
+        chunksIVs.put(1, "XXoD41zcqXc7PdpbaeG0/PDozrkSDIva2b5mpi2m6YGl7w17nWWrTy82cFGUp14rOAx99j/fRnpOigGh831CTkDnVx/s06TNajgPd7V7GEM7lhBteQhqzYBSs0i0xg53".getBytes(StandardCharsets.UTF_8));
+        chunksIVs.put(2, "lRZZ2cGACmYdAUAdFiQlkAwgaEnn/y+p+i/Osk26S6i/FoyKO048d40QfEU+ln7cjY7Fj5x8zOqmebEHc5ucPi+SpJQ32+xeCMsvZbBBj1NZUEb9A1r9teO6hk39CM+u".getBytes(StandardCharsets.UTF_8));
+        chunksIVs.put(3, "Wgz2rdaeDGi359Z0FZgXK1gTzomWLf3G91oavTo7ndKV1DlmzkDyLmXAVbjjRQ376p9J41oDqVVefTmP0Fe8c3dbKeHRy5SjopsCdiOwff5gqmjTwMLBy8bhdytGR6Q+".getBytes(StandardCharsets.UTF_8));
+
+        HashMap<Integer, String> encChunksDigests = new HashMap<>();
+        encChunksDigests.put(1, "7513E3A86A8E5E7859FB55A18C5FF70636C6D859");
+        encChunksDigests.put(2, "2ADC070DC2CE9664DC2C0EED1D813343235B5102");
+        encChunksDigests.put(3, "929B8AA1FE0C82400E7150F326D62FDB87839E12");
+
+        HashMap<Integer, String> chunksDigest = new HashMap<>();
+        chunksDigest.put(1, "E3670435119D9F4B56F014DB315EBB902FD5E309");
+        chunksDigest.put(2, "A9C71EE106C392D1B20A00066912480993DB5457");
+        chunksDigest.put(3, "84BB51D3FF74D103C0D74795C5C2E801F53AB0B2");
+
+        ComputedEncryption event10 = createEvent(ComputedEncryption.class, deposit);
+        event10.setChunkIVs(chunksIVs);
+        event10.setEncChunkDigests(encChunksDigests);
+        event10.setChunksDigest(chunksDigest);
+        event10.setAesMode("GCM");
+
+        StartCopyUpload event11 = createEvent(StartCopyUpload.class, deposit);
+        StartCopyUpload event12 = createEvent(StartCopyUpload.class, deposit);
+        StartCopyUpload event13 = createEvent(StartCopyUpload.class, deposit);
+
+        CompleteCopyUpload event14 = createEvent(CompleteCopyUpload.class, deposit);
+        event14.setArchiveId(bagId+".tar.1");
+        event14.setChunkNumber(1);
+        //event14.setArchiveStoreId(archiveStore.getID());
+
+        CompleteCopyUpload event15 = createEvent(CompleteCopyUpload.class, deposit);
+        event15.setArchiveId(bagId+".tar.2");
+        event15.setChunkNumber(2);
+        //event15.setArchiveStoreId(archiveStore.getID());
+
+        CompleteCopyUpload event16 = createEvent(CompleteCopyUpload.class, deposit);
+        event16.setArchiveId(bagId+".tar.3");
+        event16.setChunkNumber(3);
+        //event16.setArchiveStoreId(archiveStore.getID());
+
+        UpdateProgress event17 = createEvent(UpdateProgress.class, deposit);
+        UpdateProgress event18 = createEvent(UpdateProgress.class, deposit);
+        UpdateProgress event19 = createEvent(UpdateProgress.class, deposit);
+
+        UpdateProgress event20 = createEvent(UpdateProgress.class, deposit);
+
+        UploadComplete event21 = createEvent(UploadComplete.class, deposit);
+        event21.setArchiveIds(archiveIdsHashMap);
+        event21.setArchiveStoreId(archiveStore.getID());
+        event21.withNextState(4);
+
+        ValidationComplete event22 = createEvent(ValidationComplete.class, deposit);
+
+        Complete event23 = createEvent(Complete.class, deposit);
+        event23.setArchiveIds(archiveIdsHashMap);
+        event23.withNextState(5);
+        event23.setArchiveSize(50022400);
+
+        List<Event> events = List.of(
+                event1, event2, event3, event4, event5,
+                event6, event7, event8, event9, event10,
+                event11, event12, event13, event14, event15,
+                event16, event17, event18, event19, event20,
+                event21, event22, event23 );
+        
+        int count = events.size();
+        for(int i=0;i<events.size();i++) {
+            Event event = events.get(i);
+            String messageId = sendBrokerEvent(event);
+            TestUtils.waitUntil(() -> processedMessageIds.contains(messageId));
+            int idx = i  + 1;
+            log.info("broker processed message id [{}/{}] [{}] - ",idx, count, messageId);
+        }
+        assertThat(processedMessageIds).hasSize(23);
+        System.out.println("PROCESSED ALL BROKER EVENTS");
+    }
+
+    @SneakyThrows
+    private String sendBrokerEvent(Event event) {
+        String json = mapper.writeValueAsString(event);
+        MessageProperties props = new MessageProperties();
+        props.setMessageId(UUID.randomUUID().toString());
+        Message message = new Message(json.getBytes(StandardCharsets.UTF_8), props);
+        rabbitTemplate.send(this.queueNameToBroker, message);
+        return props.getMessageId();
+    }
+
+    @SneakyThrows
+    private <T extends Event>  T createEvent(Class<T> eventClass, Deposit deposit) {
+        T event = eventClass.getConstructor().newInstance();
+        event.setDepositId(deposit.getID());
+        event.setJobId(jobDAO.findByDepositIdOrderByTimestampDesc(deposit.getID()).get(0).getID());
+        event.setUserId(deposit.getUser().getID());
+        event.setTimestamp(new Date());
+        event.setAgent("43068@datavault-worker");
+        event.setAgentType(Agent.AgentType.WORKER);
+        event.setEventClass(eventClass.getName());
+        event.setMessage("MESSAGE FOR - " + event.getEventClass());
+        return event;
+    }
+    
+    private String toString(Message message){
+        return new String(message.getBody(), StandardCharsets.UTF_8);
+    }
+    @SneakyThrows
+    private String toPrettyJson(String rawJson) {
+        JsonNode node = mapper.readTree(rawJson);
+        String result = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(node);
+        return result;
+    }
+    
+}

--- a/datavault-broker/src/test/java/org/datavaultplatform/broker/queue/EventListenerTest.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/broker/queue/EventListenerTest.java
@@ -155,6 +155,8 @@ public class EventListenerTest {
   @Mock
   AuditsService auditsService;
 
+  MessageIdProcessedListener messageIdProcessedListener = new MessageIdProcessedListener();
+  
   @Mock
   TaskTimerSupport eventTimerSupport;
 
@@ -188,7 +190,7 @@ public class EventListenerTest {
         homeUrl,
         helpUrl,
         helpMail,
-        auditAdminEmail);
+        auditAdminEmail, messageIdProcessedListener);
   }
 
   @Nested
@@ -1750,7 +1752,8 @@ public class EventListenerTest {
       job.setState(1);
 
       Event event = new Event();
-      event.nextState = nextState;
+      event.setNextState(nextState);
+      
 
       sut.updateJobToNextState(event, job);
 
@@ -1782,7 +1785,7 @@ public class EventListenerTest {
       job.setState(currentState);
 
       Event event = new Event();
-      event.nextState = nextState;
+      event.setNextState(nextState);
 
       sut.updateJobToNextState(event, job);
 
@@ -2112,7 +2115,7 @@ public class EventListenerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {1,2})
+    @ValueSource(ints = {1})
     void testProcessAuditChunkStatus(int numChunkStatus) {
       Audit mAudit = mock(Audit.class);
       DepositChunk mDepositChunk = mock(DepositChunk.class);

--- a/datavault-broker/src/test/java/org/datavaultplatform/common/model/dao/ArchiveStoreDAOIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/common/model/dao/ArchiveStoreDAOIT.java
@@ -1,5 +1,6 @@
 package org.datavaultplatform.common.model.dao;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -36,6 +37,13 @@ public class ArchiveStoreDAOIT extends BaseDatabaseTest {
   @Autowired
   JdbcTemplate template;
 
+  @Test
+  void testWhenNoArchiveStores(){
+    assertThat(dao.count()).isEqualTo(0);
+    ArchiveStore result = dao.findForRetrieval();
+    assertThat(result).isNull();
+  }
+  
   @Test
   void testWriteThenRead() {
     ArchiveStore archiveStore1 = getArchiveStore1();

--- a/datavault-broker/src/test/java/org/datavaultplatform/common/model/dao/DepositDAOIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/common/model/dao/DepositDAOIT.java
@@ -300,11 +300,11 @@ public class DepositDAOIT extends BaseReuseDatabaseTest {
     assertEquals(3, items4.size());
     assertEquals(List.of("name3","name34","name345"),items4.stream().map(Deposit::getName).toList());
 
-    List<Deposit> items5 = dao.list("name3","allowed2","name","asc",1,Integer.MAX_VALUE);
+    List<Deposit> items5 = dao.list("name3","allowed2","name","asc",1, 100);
     assertEquals(2, items5.size());
     assertEquals(List.of("name34","name345"),items5.stream().map(Deposit::getName).toList());
 
-    List<Deposit> items6 = dao.list("name3","allowed2","name","desc",1,Integer.MAX_VALUE);
+    List<Deposit> items6 = dao.list("name3","allowed2","name","desc",1, 100);
     assertEquals(2, items6.size());
     assertEquals(List.of("name34","name345"),items5.stream().map(Deposit::getName).toList());
 

--- a/datavault-broker/src/test/java/org/datavaultplatform/common/model/dao/EventDAOIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/common/model/dao/EventDAOIT.java
@@ -723,19 +723,19 @@ public class EventDAOIT extends BaseDatabaseTest {
         assertThat(fromDb.getMessage()).isNotNull();
 
         if (fromDb instanceof RetrieveError) {
-          assertThat(fromDb.message).isEqualTo("message00");
+          assertThat(fromDb.getMessage()).isEqualTo("message00");
         } else if (fromDb instanceof RetrieveStart) {
-          assertThat(fromDb.message).isEqualTo(RetrieveStart.MESSAGE);
+          assertThat(fromDb.getMessage()).isEqualTo(RetrieveStart.MESSAGE);
         } else if (fromDb instanceof UserStoreSpaceAvailableChecked) {
-          assertThat(fromDb.message).isEqualTo(UserStoreSpaceAvailableChecked.MESSAGE);
+          assertThat(fromDb.getMessage()).isEqualTo(UserStoreSpaceAvailableChecked.MESSAGE);
         } else if (fromDb instanceof ArchiveStoreRetrievedChunk) {
-          assertThat(fromDb.message).isEqualTo(ArchiveStoreRetrievedChunk.MESSAGE);
+          assertThat(fromDb.getMessage()).isEqualTo(ArchiveStoreRetrievedChunk.MESSAGE);
         } else if (fromDb instanceof ArchiveStoreRetrievedAll) {
-          assertThat(fromDb.message).isEqualTo(ArchiveStoreRetrievedAll.MESSAGE);
+          assertThat(fromDb.getMessage()).isEqualTo(ArchiveStoreRetrievedAll.MESSAGE);
         } else if (fromDb instanceof UploadedToUserStore) {
-          assertThat(fromDb.message).isEqualTo(UploadedToUserStore.MESSAGE);
+          assertThat(fromDb.getMessage()).isEqualTo(UploadedToUserStore.MESSAGE);
         } else if (fromDb instanceof RetrieveComplete) {
-          assertThat(fromDb.message).isEqualTo(RetrieveComplete.MESSAGE);
+          assertThat(fromDb.getMessage()).isEqualTo(RetrieveComplete.MESSAGE);
         } else {
           throw new IllegalStateException("unexpected event " + fromDb.getClass().getName());
         }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/Error.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/Error.java
@@ -17,14 +17,14 @@ public class Error extends Event {
 
         // Optional?
         this.depositId = depositId;
-        this.jobId = jobId;
+        setJobId(jobId);
     }
 
     public Error(String jobId, String sourceId, String message, Type type) {
         super(message);
         this.eventClass = Error.class.getCanonicalName();
 
-        this.jobId = jobId;
+        setJobId(jobId);
         switch (type){
             case DEPOSIT:
                 this.depositId = sourceId;

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/Event.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/Event.java
@@ -134,107 +134,107 @@ public class Event {
     // Event properties
     @Lob
     @Column(name = "message", columnDefinition = "LONGTEXT", length = 4000)
-    public String message;
-    public String retrieveId;
-    public String eventClass;
+    protected String message;
+    protected String retrieveId;
+    protected String eventClass;
     
     @Transient
-    public Integer nextState = null;
+    protected Integer nextState = null;
     
     // Serialise date in ISO 8601 format
     @JsonFormat(shape=JsonFormat.Shape.STRING, pattern= DateTimeUtils.ISO_DATE_TIME_FORMAT)
     @Temporal(TemporalType.TIMESTAMP)
-    private Date timestamp;
-    public int sequence;
+    protected Date timestamp;
+    protected int sequence;
 
     // By default events are persisted
     @Transient
-    public Boolean persistent = true;
+    protected Boolean persistent = true;
     
     // Related deposit
     @JsonIgnore
     @ManyToOne
-    private Deposit deposit;
+    protected Deposit deposit;
     @Transient
-    public String depositId;
+    protected String depositId;
     
     // Related vault
     @JsonIgnore
     @ManyToOne
-    private Vault vault;
+    protected Vault vault;
     @Transient
-    public String vaultId;
+    protected String vaultId;
     
     // Related job
     @JsonIgnore
     @ManyToOne
-    private Job job;
+    protected Job job;
     @Transient
-    public String jobId;
+    protected String jobId;
     
     // Related user
     @JsonIgnore
     @ManyToOne
-    private User user;
+    protected User user;
     @Transient
-    public String userId;
+    protected String userId;
     
     // Event agent
-    private String agent;
+    protected String agent;
     
     // Web request properties
-    public String remoteAddress;
-    public String userAgent;
+    protected String remoteAddress;
+    protected String userAgent;
     
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(255)")
-    private Agent.AgentType agentType;
+    protected Agent.AgentType agentType;
 
     // For Audit
 
     // Related audit
     @JsonIgnore
     @ManyToOne
-    private Audit audit;
+    protected Audit audit;
     @Transient
-    public String auditId;
+    protected String auditId;
 
     // Related archive
     @JsonIgnore
     @ManyToOne
-    private Archive archive;
+    protected Archive archive;
     @Transient
-    public String archiveId;
+    protected String archiveId;
 
-    private String location;
+    protected String location;
 
     // Related deposit chunk
     @JsonIgnore
     @ManyToOne
-    private DepositChunk chunk;
+    protected DepositChunk chunk;
     @Transient
-    public String chunkId;
+    protected String chunkId;
 
     // Related Role assignee
     @JsonIgnore
     @ManyToOne
-    private User assignee;
+    protected User assignee;
     @Transient
-    public String assigneeId;
+    protected String assigneeId;
 
     // Related Role school target
     @JsonIgnore
     @ManyToOne
-    private Group school;
+    protected Group school;
     @Transient
-    public String schoolId;
+    protected String schoolId;
 
     // Related Role target
     @JsonIgnore
     @ManyToOne
-    private RoleModel role;
+    protected RoleModel role;
     @Transient
-    public String roleId;
+    protected String roleId;
 
     @Getter
     @Setter
@@ -298,6 +298,7 @@ public class Event {
         this.message = message;
     }
 
+    @JsonGetter
     public String getJobId() {
         return jobId;
     }
@@ -306,6 +307,7 @@ public class Event {
         this.jobId = jobId;
     }
 
+    @JsonGetter
     public String getDepositId() {
         return depositId;
     }
@@ -314,6 +316,7 @@ public class Event {
         this.depositId = depositId;
     }
 
+    @JsonGetter
     public String getVaultId() {
         return vaultId;
     }
@@ -322,14 +325,17 @@ public class Event {
         this.vaultId = vaultId;
     }
     
+    @JsonGetter
     public String getUserId() {
         return userId;
     }
 
+    @JsonSetter
     public void setUserId(String userId) {
         this.userId = userId;
     }
 
+    @JsonGetter
     public String getAgent() {
         return agent;
     }
@@ -338,6 +344,7 @@ public class Event {
         this.agent = agent;
     }
 
+    @JsonGetter
     public Agent.AgentType getAgentType() {
         return agentType;
     }
@@ -346,6 +353,7 @@ public class Event {
         this.agentType = agentType;
     }
 
+    @JsonGetter
     public String getRemoteAddress() {
         return remoteAddress;
     }
@@ -354,6 +362,7 @@ public class Event {
         this.remoteAddress = remoteAddress;
     }
 
+    @JsonGetter
     public String getUserAgent() {
         return userAgent;
     }
@@ -362,6 +371,7 @@ public class Event {
         this.userAgent = userAgent;
     }
     
+    @JsonGetter
     public String getRetrieveId() {
         return retrieveId;
     }
@@ -369,7 +379,9 @@ public class Event {
     public void setRetrieveId(String retrieveId) {
         this.retrieveId = retrieveId;
     }
+    
 
+    @JsonGetter
     public Boolean getPersistent() {
         return persistent;
     }
@@ -378,6 +390,7 @@ public class Event {
         this.persistent = persistent;
     }
 
+    @JsonGetter
     public int getSequence() {
         return sequence;
     }
@@ -386,6 +399,7 @@ public class Event {
         this.sequence = sequence;
     }
 
+    @JsonGetter
     public Date getTimestamp() {
         return timestamp;
     }
@@ -393,7 +407,7 @@ public class Event {
     public void setTimestamp(Date timestamp) {
         this.timestamp = timestamp;
     }
-
+    
     public Job getJob() {
         return job;
     }
@@ -425,7 +439,57 @@ public class Event {
     public void setUser(User user) {
         this.user = user;
     }
-    
+
+    @JsonGetter
+    public Integer getNextState() {
+        return nextState;
+    }
+
+    public void setNextState(Integer nextState) {
+        this.nextState = nextState;
+    }
+
+    public Audit getAudit() {
+        return audit;
+    }
+
+    public void setAudit(Audit audit) {
+        this.audit = audit;
+    }
+
+    public Archive getArchive() {
+        return archive;
+    }
+
+    public void setArchive(Archive archive) {
+        this.archive = archive;
+    }
+
+    public DepositChunk getChunk() {
+        return chunk;
+    }
+
+    public void setChunk(DepositChunk chunk) {
+        this.chunk = chunk;
+    }
+
+    @JsonGetter
+    public Integer getChunkNumber() {
+        return chunkNumber;
+    }
+
+    public void setChunkNumber(Integer chunkNumber) {
+        this.chunkNumber = chunkNumber;
+    }
+
+    public String getArchiveStoreId() {
+        return archiveStoreId;
+    }
+
+    public void setArchiveStoreId(String archiveStoreId) {
+        this.archiveStoreId = archiveStoreId;
+    }
+
     public Event withNextState(Integer state) {
         this.nextState = state;
         return this;
@@ -455,14 +519,17 @@ public class Event {
                 userAgent);
     }
 
+    @JsonGetter
     public String getAuditId() { return auditId; }
 
     public void setAuditId(String auditId) { this.auditId = auditId; }
 
+    @JsonGetter
     public String getChunkId() { return chunkId; }
 
     public void setChunkId(String chunkId) { this.chunkId = chunkId; }
 
+    @JsonGetter
     public String getArchiveId() { return archiveId; }
 
     public void setArchiveId(String archiveId) { this.archiveId = archiveId; }
@@ -471,6 +538,7 @@ public class Event {
 
     public void setLocation(String location) { this.location = location; }
 
+    @JsonGetter
     public String getAssigneeId() {
         return assigneeId;
     }
@@ -479,6 +547,7 @@ public class Event {
         this.assigneeId = assigneeId;
     }
 
+    @JsonGetter
     public String getSchoolId() {
         return schoolId;
     }
@@ -487,6 +556,7 @@ public class Event {
         this.schoolId = schoolId;
     }
 
+    @JsonGetter
     public String getRoleId() {
         return roleId;
     }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/InitStates.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/InitStates.java
@@ -1,5 +1,6 @@
 package org.datavaultplatform.common.event;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import jakarta.persistence.Entity;
 import java.util.ArrayList;
 import jakarta.persistence.Transient;
@@ -8,7 +9,7 @@ import jakarta.persistence.Transient;
 public class InitStates extends Event {
 
     @Transient
-    private ArrayList<String> states;
+    protected ArrayList<String> states;
     
     public InitStates() {
     }
@@ -20,9 +21,10 @@ public class InitStates extends Event {
         
         // Optional?
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
 
+    @JsonGetter
     public ArrayList<String> getStates() {
         return states;
     }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/UpdateProgress.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/UpdateProgress.java
@@ -7,13 +7,13 @@ import jakarta.persistence.Transient;
 public class UpdateProgress extends Event {
     
     @Transient
-    public long progress;
+    protected long progress;
     
     @Transient
-    public long progressMax;
+    protected long progressMax;
     
     @Transient
-    public String progressMessage;
+    protected String progressMessage;
     
     public UpdateProgress() {
     }
@@ -30,7 +30,7 @@ public class UpdateProgress extends Event {
         
         // Optional?
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
     
     public long getProgress() {

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/delete/DeleteComplete.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/delete/DeleteComplete.java
@@ -13,6 +13,6 @@ public class DeleteComplete extends Event {
     	super("Deposit Delete finished");
         this.eventClass = DeleteComplete.class.getCanonicalName();
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/delete/DeleteStart.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/delete/DeleteStart.java
@@ -13,6 +13,6 @@ public class DeleteStart extends Event {
         super("Deposit delete started");
         this.eventClass = DeleteStart.class.getCanonicalName();
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/ChunksDigestEvent.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/ChunksDigestEvent.java
@@ -1,8 +1,13 @@
 package org.datavaultplatform.common.event.deposit;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+
 import java.util.Map;
 
 public interface ChunksDigestEvent {
+  @JsonGetter
   Map<Integer, String> getChunksDigest();
+
+  @JsonGetter
   String getDigestAlgorithm();
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/Complete.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/Complete.java
@@ -1,6 +1,8 @@
 package org.datavaultplatform.common.event.deposit;
 
 import java.util.HashMap;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Convert;
@@ -17,8 +19,7 @@ public class Complete extends Event {
     @Column(name = "archiveIds", columnDefinition="TINYBLOB")
     private HashMap<String, String> archiveIds = new HashMap<>();
 
-    //public String archiveId;
-    public long archiveSize;
+    private long archiveSize;
 
     public Complete() {}
     public Complete(String jobId, String depositId, HashMap<String, String> archiveIds, long archiveSize) {
@@ -29,9 +30,10 @@ public class Complete extends Event {
         this.archiveIds = archiveIds;
         this.archiveSize = archiveSize;
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
 
+    @JsonGetter
     public HashMap<String, String> getArchiveIds() {
         return archiveIds;
     }
@@ -40,6 +42,7 @@ public class Complete extends Event {
         this.archiveIds = archiveIds;
     }
 
+    @JsonGetter
     public long getArchiveSize() {
         return archiveSize;
     }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/CompleteChunkValidation.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/CompleteChunkValidation.java
@@ -12,6 +12,6 @@ public class CompleteChunkValidation extends Event {
         super("Chunk " + chunkNum + " validation finished - (" + type + ")");
         this.eventClass = CompleteChunkValidation.class.getCanonicalName();
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/CompleteCopyUpload.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/CompleteCopyUpload.java
@@ -23,7 +23,7 @@ public class CompleteCopyUpload extends Event {
 		
 		this.eventClass = CompleteCopyUpload.class.getCanonicalName();
 		this.depositId = depositId;
-		this.jobId = jobId;
+		this.setJobId(jobId);
 		this.setChunkNumber(chunkNumber);
 		this.setArchiveStoreId(archiveStoreId);
 		this.archiveId = archiveId;

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/CompleteTarValidation.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/CompleteTarValidation.java
@@ -11,7 +11,7 @@ public class CompleteTarValidation extends Event {
     public CompleteTarValidation(String jobId, String depositId) {
         super("Tar validation completed");
         this.eventClass = CompleteTarValidation.class.getCanonicalName();
-        this.depositId = depositId;
-        this.jobId = jobId;
+        this.setDepositId(depositId);
+        this.setJobId(jobId);
     }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/ComputedChunks.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/ComputedChunks.java
@@ -2,6 +2,7 @@ package org.datavaultplatform.common.event.deposit;
 
 import java.util.HashMap;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
@@ -15,9 +16,9 @@ public class ComputedChunks extends Event implements ChunksDigestEvent {
     @Lob
     @Convert(converter = HashMapConverter.IntegerString.class)
     @Column(name="chunksDigest", columnDefinition="LONGBLOB")
-    public HashMap<Integer, String> chunksDigest = new HashMap<>();
+    private HashMap<Integer, String> chunksDigest = new HashMap<>();
 
-    public String digestAlgorithm;
+    private String digestAlgorithm;
     
     public ComputedChunks() {
     }
@@ -31,9 +32,10 @@ public class ComputedChunks extends Event implements ChunksDigestEvent {
         this.chunksDigest = chunksDigest;
         this.digestAlgorithm = digestAlgorithm;
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
     
+    @JsonGetter
     public HashMap<Integer, String> getChunksDigest() {
         return chunksDigest;
     }
@@ -42,6 +44,7 @@ public class ComputedChunks extends Event implements ChunksDigestEvent {
         this.chunksDigest = chunksDigest;
     }
     
+    @JsonGetter
     public String getDigestAlgorithm() {
         return digestAlgorithm;
     }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/ComputedDigest.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/ComputedDigest.java
@@ -17,7 +17,7 @@ public class ComputedDigest extends Event {
         this.digest = digest;
         this.digestAlgorithm = digestAlgorithm;
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
 
     public String getDigest() {

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/ComputedEncryption.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/ComputedEncryption.java
@@ -55,7 +55,7 @@ public class ComputedEncryption extends Event implements ChunksDigestEvent {
         this.setAesMode(aesMode);
         this.encChunkDigests = digests;
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
         this.chunksDigest = chunksDigest;
         this.digestAlgorithm = digestAlgorithm;
     }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/ComputedSize.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/ComputedSize.java
@@ -1,12 +1,13 @@
 package org.datavaultplatform.common.event.deposit;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import jakarta.persistence.Entity;
 import org.datavaultplatform.common.event.Event;
 
 @Entity
 public class ComputedSize extends Event {
     
-    public long bytes;
+    private long bytes;
 
     public ComputedSize() {
     }
@@ -15,9 +16,10 @@ public class ComputedSize extends Event {
         this.eventClass = ComputedSize.class.getCanonicalName();
         this.bytes = bytes;
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
     
+    @JsonGetter
     public long getBytes() {
         return bytes;
     }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/PackageComplete.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/PackageComplete.java
@@ -12,6 +12,6 @@ public class PackageComplete extends Event {
         super("Packaging completed");
         this.eventClass = PackageComplete.class.getCanonicalName();
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/Start.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/Start.java
@@ -12,6 +12,6 @@ public class Start extends Event {
         super("Deposit started");
         this.eventClass = Start.class.getCanonicalName();
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/StartChunkValidation.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/StartChunkValidation.java
@@ -12,6 +12,6 @@ public class StartChunkValidation extends Event {
         super("Chunk " + chunkNum + " validation started - (" + type + ")");
         this.eventClass = StartChunkValidation.class.getCanonicalName();
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/StartCopyUpload.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/StartCopyUpload.java
@@ -14,6 +14,6 @@ public class StartCopyUpload extends Event {
 		super("Chunk " + optChunkNumber + " upload started - (" + type + ")");
 		this.eventClass = StartCopyUpload.class.getCanonicalName();
 		this.depositId = depositId;
-		this.jobId = jobId;
+		this.setJobId(jobId);
 	}
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/StartTarValidation.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/StartTarValidation.java
@@ -12,6 +12,6 @@ public class StartTarValidation extends Event {
         super("Tar validation started");
         this.eventClass = StartTarValidation.class.getCanonicalName();
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/TransferComplete.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/TransferComplete.java
@@ -12,6 +12,6 @@ public class TransferComplete extends Event {
         super("File transfer completed");
         this.eventClass = TransferComplete.class.getCanonicalName();
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/TransferProgress.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/TransferProgress.java
@@ -1,14 +1,15 @@
 package org.datavaultplatform.common.event.deposit;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import jakarta.persistence.Transient;
 import org.datavaultplatform.common.event.Event;
 
 public class TransferProgress extends Event {
     
-    public long bytes;
+    private long bytes;
     
     @Transient
-    public long bytesPerSec;
+    private long bytesPerSec;
 
     public TransferProgress() {
         this.eventClass = TransferProgress.class.getCanonicalName();
@@ -21,9 +22,10 @@ public class TransferProgress extends Event {
         this.bytesPerSec = bytesPerSec;
         this.persistent = false;
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
     
+    @JsonGetter
     public long getBytes() {
         return bytes;
     }
@@ -32,6 +34,7 @@ public class TransferProgress extends Event {
         this.bytes = bytes;
     }
 
+    @JsonGetter
     public long getBytesPerSec() {
         return bytesPerSec;
     }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/UploadComplete.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/UploadComplete.java
@@ -16,7 +16,7 @@ public class UploadComplete extends Event {
     @Lob
     @Convert(converter = HashMapConverter.StringString.class)
     @Column(name="archiveIds", columnDefinition="TINYBLOB")
-    HashMap<String, String> archiveIds = new HashMap<>();
+    private HashMap<String, String> archiveIds = new HashMap<>();
 
     public UploadComplete() {
     }
@@ -25,7 +25,7 @@ public class UploadComplete extends Event {
         super("Upload completed");
         this.eventClass = UploadComplete.class.getCanonicalName();
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
         this.archiveIds = archiveIds;
     }
 

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/ValidationComplete.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/deposit/ValidationComplete.java
@@ -12,6 +12,6 @@ public class ValidationComplete extends Event {
         super("Validation completed");
         this.eventClass = ValidationComplete.class.getCanonicalName();
         this.depositId = depositId;
-        this.jobId = jobId;
+        this.setJobId(jobId);
     }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/event/retrieve/BaseRetrieveEvent.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/event/retrieve/BaseRetrieveEvent.java
@@ -10,7 +10,7 @@ public abstract class BaseRetrieveEvent extends Event {
 
     public BaseRetrieveEvent(String jobId, String depositId, String retrieveId) {
         this();
-        this.jobId = jobId;
+        this.setJobId(jobId);
         this.depositId = depositId;
         this.retrieveId = retrieveId;
     }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/EventDAO.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/EventDAO.java
@@ -111,7 +111,10 @@ public interface EventDAO extends BaseDAO<Event>, EventCustomDAO {
     @Query("""
               SELECT   e
               FROM     Event e
-              WHERE    ((e.eventClass IS NULL) OR (e.eventClass <> 'org.datavaultplatform.common.event.Error'))
+              WHERE    ((e.eventClass IS NULL) 
+                OR (e.eventClass <> 'org.datavaultplatform.common.event.retrieve.RetrieveError')
+                OR (e.eventClass <> 'org.datavaultplatform.common.event.Error')
+              )
               AND      e.deposit.id = :depositId
               AND      e.job.taskClass = :jobTaskClass
               AND      e.retrieveId = :retrieveId

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/JobDAO.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/JobDAO.java
@@ -18,4 +18,6 @@ public interface JobDAO extends BaseDAO<Job> {
   @Override
   @EntityGraph(Job.EG_JOB)
   List<Job> findAll();
+  
+  List<Job> findByDepositIdOrderByTimestampDesc(String depositId);
 }

--- a/datavault-common/src/main/resources/db/retrieveRestart.sql
+++ b/datavault-common/src/main/resources/db/retrieveRestart.sql
@@ -1,0 +1,1 @@
+insert into ArchiveStores (id,label,retrieveEnabled,storageClass) values ('test-lfs-id','test-lfs-label',true,'org.datavaultplatform.common.storage.impl.LocalFileSystem');

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/DepositsController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/DepositsController.java
@@ -129,6 +129,17 @@ public class DepositsController {
     }
 
 
+    // Process the completed 'restart retrieve' page
+    @RequestMapping(value = "/vaults/{vaultid}/deposits/{depositId}/retrieves/{retrieveId}/restart", method = RequestMethod.GET)
+    public String restartRetrieve(ModelMap model,
+                                 @PathVariable("vaultid") String vaultID, @PathVariable("depositId") String depositID,
+                                 @PathVariable("retrieveId") String retrieveID) throws Exception {
+
+        restService.restartRetrieve(depositID, retrieveID);
+
+        String depositUrl = "/vaults/" + vaultID + "/deposits/" + depositID + "/";
+        return "redirect:" + depositUrl;
+    }
 
     // Process the completed 'restart deposit' page
     @RequestMapping(value = "/vaults/{vaultid}/deposits/{depositId}/restart", method = RequestMethod.GET)

--- a/datavault-webapp/src/main/webapp/WEB-INF/templates/admin/retrieves/index.html
+++ b/datavault-webapp/src/main/webapp/WEB-INF/templates/admin/retrieves/index.html
@@ -19,6 +19,7 @@
                     <th>Timestamp</th>
                     <th>Retrieve path</th>
                     <th>Retrieve note</th>
+                    <th>Actions</th>
                 </tr>
                 </thead>
 
@@ -29,6 +30,14 @@
                         <td>[[${#dates.format(retrieve.timestamp,globalDateTimeFormat)}]]<!--/* datetime */--></td>
                         <td>[[${retrieve.retrievePath}]]</td>
                         <td>[[${retrieve.note}]]</td>
+                        <td>
+                        <th:block th:if="${retrieve.status.name() == 'FAILED'}">
+                            <a class="restart-deposit-btn btn btn-default btn-sm"
+                               th:href="@{|/vaults/__${retrieve.deposit.vault.getID()}__/deposits/__${retrieve.deposit.getID()}__/retrieves/__${retrieve.getID()}__/restart|}">
+                                Restart
+                            </a>
+                        </th:block>
+                        </td>
                     </tr>
                 </tbody>
             </table>

--- a/datavault-worker/src/test/java/org/datavaultplatform/worker/operations/ProgressTrackerTest.java
+++ b/datavault-worker/src/test/java/org/datavaultplatform/worker/operations/ProgressTrackerTest.java
@@ -55,11 +55,11 @@ class ProgressTrackerTest {
         assertThat(events.size()).isEqualTo(5);
         for (int i = 0; i < events.size(); i++) {
             UpdateProgress pe = (UpdateProgress) events.get(i);
-            assertThat(pe.jobId).isEqualTo(JOB_ID);
-            assertThat(pe.depositId).isEqualTo(DEPOSIT_ID);
-            assertThat(pe.progress).isEqualTo(100 * (i + 1));
-            assertThat(pe.progressMax).isEqualTo(2112);
-            assertThat(pe.message).isEqualTo("Job progress update");
+            assertThat(pe.getJobId()).isEqualTo(JOB_ID);
+            assertThat(pe.getDepositId()).isEqualTo(DEPOSIT_ID);
+            assertThat(pe.getProgress()).isEqualTo(100 * (i + 1));
+            assertThat(pe.getProgressMax()).isEqualTo(2112);
+            assertThat(pe.getMessage()).isEqualTo("Job progress update");
         }
         log.info("FIN");
     }

--- a/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/BasePerformDepositThenRetrieveIT.java
+++ b/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/BasePerformDepositThenRetrieveIT.java
@@ -50,22 +50,7 @@ public abstract class BasePerformDepositThenRetrieveIT extends BaseDepositIT {
     log.info("retrieve dir [{}]", retrieveDir);
 
   }
-
-  @SneakyThrows
-  static Set<Path> getPathsWithinTarFile(File tarFile) {
-    Set<Path> paths = new HashSet<>();
-    try (TarArchiveInputStream tarIn = new TarArchiveInputStream(new FileInputStream(tarFile))) {
-      TarArchiveEntry entry;
-      while ((entry = tarIn.getNextEntry()) != null) {
-        if (entry.isDirectory()) {
-          continue;
-        }
-        paths.add(Paths.get(entry.getName()));
-      }
-    }
-    return paths;
-  }
-
+  
   @DynamicPropertySource
   @SneakyThrows
   static void setupProperties(DynamicPropertyRegistry registry) {

--- a/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/PerformDepositThenRetrieveMultiChunkIT.java
+++ b/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/PerformDepositThenRetrieveMultiChunkIT.java
@@ -9,10 +9,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.extern.slf4j.Slf4j;
+import org.datavaultplatform.common.event.Event;
 import org.datavaultplatform.common.event.deposit.CompleteCopyUpload;
 import org.datavaultplatform.worker.app.DataVaultWorkerInstanceApp;
 import org.datavaultplatform.worker.test.AddTestProperties;
+import org.junit.jupiter.api.AfterEach;
 import org.slf4j.Logger;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -54,5 +57,12 @@ public class PerformDepositThenRetrieveMultiChunkIT extends BasePerformDepositTh
     Logger monitorLogger() {
       return log;
     }
+  }
+  
+  @AfterEach
+  void tearDown() throws JsonProcessingException {
+    System.out.println("FIN");
+    String allJson = mapper.writeValueAsString(events);
+    System.out.println(allJson);
   }
 }

--- a/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/RetrieveRestartTest.java
+++ b/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/RetrieveRestartTest.java
@@ -229,7 +229,7 @@ public class RetrieveRestartTest {
             verify(retrieve).doRetrieveFromWorkerToUserFs(mContext, actualUserStoreInfo2, actualTarFile2, actualProgress2);
         }
 
-        var eventClasses = sentEvents.stream().map(evt -> evt.eventClass).toList();
+        var eventClasses = sentEvents.stream().map(evt -> evt.getEventClass()).toList();
         assertThat(eventClasses).isEqualTo(List.of(
                 "org.datavaultplatform.common.event.InitStates",
                 "org.datavaultplatform.common.event.retrieve.RetrieveStart",
@@ -281,7 +281,7 @@ public class RetrieveRestartTest {
             verify(retrieve).doRetrieveFromWorkerToUserFs(mContext, actualUserStoreInfo2, actualTarFile2, actualProgress2);
         }
 
-        var eventClasses = sentEvents.stream().map(evt -> evt.eventClass).toList();
+        var eventClasses = sentEvents.stream().map(evt -> evt.getEventClass()).toList();
         assertThat(eventClasses).isEqualTo(List.of(
                 //TODO : might need to check the InitStates and RetrieveStart are not sent again ?
                 "org.datavaultplatform.common.event.InitStates",
@@ -324,7 +324,7 @@ public class RetrieveRestartTest {
             verify(retrieve).doRetrieveFromWorkerToUserFs(mContext, actualUserStoreInfo2, actualTarFile2, actualProgress2);
         }
 
-        var eventClasses = sentEvents.stream().map(evt -> evt.eventClass).toList();
+        var eventClasses = sentEvents.stream().map(evt -> evt.getEventClass()).toList();
         assertThat(eventClasses).isEqualTo(List.of(
                 //TODO : might need to check the InitStates and RetrieveStart are not sent again ?
                 "org.datavaultplatform.common.event.InitStates",
@@ -373,7 +373,7 @@ public class RetrieveRestartTest {
             verify(retrieve).doRetrieveFromWorkerToUserFs(mContext, actualUserStoreInfo2, actualTarFile2, actualProgress2);
         }
 
-        var eventClasses = sentEvents.stream().map(evt -> evt.eventClass).toList();
+        var eventClasses = sentEvents.stream().map(evt -> evt.getEventClass()).toList();
         assertThat(eventClasses).isEqualTo(List.of(
                 //TODO : might need to check the InitStates and RetrieveStart are not sent again ?
                 "org.datavaultplatform.common.event.InitStates",
@@ -417,7 +417,7 @@ public class RetrieveRestartTest {
 
         var eventClasses = sentEvents.stream()
                 .filter(e -> !(e instanceof UpdateProgress))
-                .map(evt -> evt.eventClass).toList();
+                .map(evt -> evt.getEventClass()).toList();
         assertThat(eventClasses).isEqualTo(List.of(
                 //TODO : might need to check the InitStates and RetrieveStart are not sent again ?
                 "org.datavaultplatform.common.event.InitStates",

--- a/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/deposit/DepositPackagerTest.java
+++ b/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/deposit/DepositPackagerTest.java
@@ -244,18 +244,18 @@ class DepositPackagerTest {
 
             assertThat(eventsSent.size()).isEqualTo(3);
             PackageComplete event1 = (PackageComplete) eventsSent.get(0);
-            assertThat(event1.depositId).isEqualTo(TEST_DEPOSIT_ID);
-            assertThat(event1.jobId).isEqualTo(TEST_JOB_ID);
+            assertThat(event1.getDepositId()).isEqualTo(TEST_DEPOSIT_ID);
+            assertThat(event1.getJobId()).isEqualTo(TEST_JOB_ID);
 
             ComputedDigest event2 = (ComputedDigest) eventsSent.get(1);
-            assertThat(event2.depositId).isEqualTo(TEST_DEPOSIT_ID);
-            assertThat(event2.jobId).isEqualTo(TEST_JOB_ID);
+            assertThat(event2.getDepositId()).isEqualTo(TEST_DEPOSIT_ID);
+            assertThat(event2.getJobId()).isEqualTo(TEST_JOB_ID);
             assertThat(event2.getDigest()).isEqualTo("TEST-DIGEST");
             assertThat(event2.getDigestAlgorithm()).isEqualTo("SHA-1");
 
             ComputedEncryption event3 = (ComputedEncryption) eventsSent.get(2);
-            assertThat(event3.depositId).isEqualTo(TEST_DEPOSIT_ID);
-            assertThat(event3.jobId).isEqualTo(TEST_JOB_ID);
+            assertThat(event3.getDepositId()).isEqualTo(TEST_DEPOSIT_ID);
+            assertThat(event3.getJobId()).isEqualTo(TEST_JOB_ID);
 
             assertThat(event3.getChunkIVs()).isEqualTo(result.getChunksIVs());
             assertThat(event3.getEncChunkDigests()).isEqualTo(result.getEncChunkHashes());
@@ -343,18 +343,18 @@ class DepositPackagerTest {
 
             assertThat(eventsSent.size()).isEqualTo(3);
             PackageComplete event1 = (PackageComplete) eventsSent.get(0);
-            assertThat(event1.depositId).isEqualTo(TEST_DEPOSIT_ID);
-            assertThat(event1.jobId).isEqualTo(TEST_JOB_ID);
+            assertThat(event1.getDepositId()).isEqualTo(TEST_DEPOSIT_ID);
+            assertThat(event1.getJobId()).isEqualTo(TEST_JOB_ID);
 
             ComputedDigest event2 = (ComputedDigest) eventsSent.get(1);
-            assertThat(event2.depositId).isEqualTo(TEST_DEPOSIT_ID);
-            assertThat(event2.jobId).isEqualTo(TEST_JOB_ID);
+            assertThat(event2.getDepositId()).isEqualTo(TEST_DEPOSIT_ID);
+            assertThat(event2.getJobId()).isEqualTo(TEST_JOB_ID);
             assertThat(event2.getDigest()).isEqualTo("TEST-DIGEST");
             assertThat(event2.getDigestAlgorithm()).isEqualTo("SHA-1");
 
             ComputedEncryption event3 = (ComputedEncryption) eventsSent.get(2);
-            assertThat(event3.depositId).isEqualTo(TEST_DEPOSIT_ID);
-            assertThat(event3.jobId).isEqualTo(TEST_JOB_ID);
+            assertThat(event3.getDepositId()).isEqualTo(TEST_DEPOSIT_ID);
+            assertThat(event3.getJobId()).isEqualTo(TEST_JOB_ID);
 
             assertThat(event3.getChunkIVs()).isNull();
             assertThat(event3.getEncChunkDigests()).isNull();
@@ -449,18 +449,18 @@ class DepositPackagerTest {
 
             assertThat(eventsSent.size()).isEqualTo(3);
             PackageComplete event1 = (PackageComplete) eventsSent.get(0);
-            assertThat(event1.depositId).isEqualTo(TEST_DEPOSIT_ID);
-            assertThat(event1.jobId).isEqualTo(TEST_JOB_ID);
+            assertThat(event1.getDepositId()).isEqualTo(TEST_DEPOSIT_ID);
+            assertThat(event1.getJobId()).isEqualTo(TEST_JOB_ID);
 
             ComputedDigest event2 = (ComputedDigest) eventsSent.get(1);
-            assertThat(event2.depositId).isEqualTo(TEST_DEPOSIT_ID);
-            assertThat(event2.jobId).isEqualTo(TEST_JOB_ID);
+            assertThat(event2.getDepositId()).isEqualTo(TEST_DEPOSIT_ID);
+            assertThat(event2.getJobId()).isEqualTo(TEST_JOB_ID);
             assertThat(event2.getDigest()).isEqualTo("TEST-DIGEST");
             assertThat(event2.getDigestAlgorithm()).isEqualTo("SHA-1");
 
             ComputedChunks event3 = (ComputedChunks) eventsSent.get(2);
-            assertThat(event3.depositId).isEqualTo(TEST_DEPOSIT_ID);
-            assertThat(event3.jobId).isEqualTo(TEST_JOB_ID);
+            assertThat(event3.getDepositId()).isEqualTo(TEST_DEPOSIT_ID);
+            assertThat(event3.getJobId()).isEqualTo(TEST_JOB_ID);
 
             assertThat(event3.getChunksDigest()).isEqualTo(result.getChunkHashes());
 
@@ -530,12 +530,12 @@ class DepositPackagerTest {
 
             assertThat(eventsSent.size()).isEqualTo(2);
             PackageComplete event1 = (PackageComplete) eventsSent.get(0);
-            assertThat(event1.depositId).isEqualTo(TEST_DEPOSIT_ID);
-            assertThat(event1.jobId).isEqualTo(TEST_JOB_ID);
+            assertThat(event1.getDepositId()).isEqualTo(TEST_DEPOSIT_ID);
+            assertThat(event1.getJobId()).isEqualTo(TEST_JOB_ID);
 
             ComputedDigest event2 = (ComputedDigest) eventsSent.get(1);
-            assertThat(event2.depositId).isEqualTo(TEST_DEPOSIT_ID);
-            assertThat(event2.jobId).isEqualTo(TEST_JOB_ID);
+            assertThat(event2.getDepositId()).isEqualTo(TEST_DEPOSIT_ID);
+            assertThat(event2.getJobId()).isEqualTo(TEST_JOB_ID);
             assertThat(event2.getDigest()).isEqualTo("TEST-DIGEST");
             assertThat(event2.getDigestAlgorithm()).isEqualTo("SHA-1");
 

--- a/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/deposit/DepositSizeComputerTest.java
+++ b/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/deposit/DepositSizeComputerTest.java
@@ -125,9 +125,9 @@ class DepositSizeComputerTest {
             Event actualEvent = argEvent.getValue();
             assertThat(actualEvent).isInstanceOf(ComputedSize.class);
             ComputedSize cs = (ComputedSize) actualEvent;
-            assertThat(cs.bytes).isEqualTo(expectedSize);
-            assertThat(cs.depositId).isEqualTo("depositId");
-            assertThat(cs.jobId).isEqualTo("jobId");
+            assertThat(cs.getBytes()).isEqualTo(expectedSize);
+            assertThat(cs.getDepositId()).isEqualTo("depositId");
+            assertThat(cs.getJobId()).isEqualTo("jobId");
             verify(mUserEventSender).send(actualEvent);
             verifyNoMoreInteractions(mUserEventSender);
         }
@@ -142,9 +142,9 @@ class DepositSizeComputerTest {
             Event actualEvent = argEvent.getValue();
             assertThat(actualEvent).isInstanceOf(Error.class);
             Error err = (Error) actualEvent;
-            assertThat(err.message).isEqualTo("Deposit failed: could not access user filesystem");
-            assertThat(err.depositId).isEqualTo("depositId");
-            assertThat(err.jobId).isEqualTo("jobId");
+            assertThat(err.getMessage()).isEqualTo("Deposit failed: could not access user filesystem");
+            assertThat(err.getDepositId()).isEqualTo("depositId");
+            assertThat(err.getJobId()).isEqualTo("jobId");
             verify(mUserEventSender).send(actualEvent);
             verifyNoMoreInteractions(mUserEventSender);
 

--- a/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/deposit/DepositUserStoreDownloaderTest.java
+++ b/datavault-worker/src/test/java/org/datavaultplatform/worker/tasks/deposit/DepositUserStoreDownloaderTest.java
@@ -412,20 +412,20 @@ class DepositUserStoreDownloaderTest {
         List<Event> nonProgressEvents = argEvent.getAllValues().stream().filter(e -> !(e instanceof UpdateProgress)).toList();
         assertThat(nonProgressEvents).hasSize(1);
         TransferComplete tc = (TransferComplete) nonProgressEvents.get(0);
-        assertThat(tc.depositId).isEqualTo(DEPOSIT_ID);
-        assertThat(tc.jobId).isEqualTo(JOB_ID);
-        assertThat(tc.eventClass).isEqualTo(TransferComplete.class.getName());
-        assertThat(tc.message).isEqualTo("File transfer completed");
+        assertThat(tc.getDepositId()).isEqualTo(DEPOSIT_ID);
+        assertThat(tc.getJobId()).isEqualTo(JOB_ID);
+        assertThat(tc.getEventClass()).isEqualTo(TransferComplete.class.getName());
+        assertThat(tc.getMessage()).isEqualTo("File transfer completed");
     }
     
     private void checkErrorEvent(String msg) {
         List<Event> nonProgressEvents = argEvent.getAllValues().stream().filter(e -> !(e instanceof UpdateProgress)).toList();
         assertThat(nonProgressEvents).hasSize(1);
         Error error = (Error) nonProgressEvents.get(0);
-        assertThat(error.depositId).isEqualTo(DEPOSIT_ID);
-        assertThat(error.jobId).isEqualTo(JOB_ID);
-        assertThat(error.eventClass).isEqualTo(Error.class.getName());
-        assertThat(error.message).isEqualTo(msg);
+        assertThat(error.getDepositId()).isEqualTo(DEPOSIT_ID);
+        assertThat(error.getJobId()).isEqualTo(JOB_ID);
+        assertThat(error.getEventClass()).isEqualTo(Error.class.getName());
+        assertThat(error.getMessage()).isEqualTo(msg);
     }
 
     private void checkBagDataDirectoryCreated(File downloadResult, Path bagIdPath, Path bagIdDataPath) {
@@ -528,7 +528,7 @@ class DepositUserStoreDownloaderTest {
             Files.createDirectories(bagIdDataPath);
 
             Event lastEvent = new TransferComplete();
-            lastEvent.eventClass = TransferComplete.class.getName();
+            lastEvent.setEventClass(TransferComplete.class.getName());
 
             var downloader = Mockito.spy(new DepositUserStoreDownloader(USER_ID, JOB_ID, DEPOSIT_ID, SENDER, BAG_ID, CONTEXT, lastEvent, PROPS,
                     fileStorePaths, userStores, null));
@@ -549,7 +549,7 @@ class DepositUserStoreDownloaderTest {
             assertThat(Files.exists(bagIdDataPath)).isFalse();
 
             Event lastEvent = new TransferComplete();
-            lastEvent.eventClass = TransferComplete.class.getName();
+            lastEvent.setEventClass(TransferComplete.class.getName());
 
             var downloader = Mockito.spy(new DepositUserStoreDownloader(USER_ID, JOB_ID, DEPOSIT_ID, SENDER, BAG_ID, CONTEXT, lastEvent, PROPS,
                     fileStorePaths, userStores, null));


### PR DESCRIPTION
…ed retrieve

1) Remove check that the retrieve user is the same user as the depositor 2) Updated DepositsControllerTest to remove mocking of above 3) Added new restartRetrieve method to webapp/DepositsController 4) Added button to admin/retrieves/index.html

I've also added though commented out the line I think will need to be added to broker/DepositsController to make sure only admins can restart retrieves. We can add that in with the retrieve path fix