### PR TITLE
#LUC070-148 Proper fix for /admin/review (hopefully)

### DIFF
--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/VaultReview.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/VaultReview.java
@@ -74,7 +74,9 @@ public class VaultReview {
     @Column(name = "comment", nullable = true, columnDefinition = "TEXT")
     private String comment;
 
+    public VaultReview() {
 
+    }
 
     public String getId() {
         return id;

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/VaultsController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/VaultsController.java
@@ -252,11 +252,10 @@ public class VaultsController {
 
             VaultReview currentReview = restService.getVaultReview(reviewInfo.getVaultReviewId());
             VaultReviewModel vaultReviewModel = new VaultReviewModel(currentReview);
-
             List<DepositReviewModel> depositReviewModels = new ArrayList<>();
             for (int i = 0; i < reviewInfo.getDepositIds().size(); i++) {
                 DepositInfo depositInfo = restService.getDeposit(reviewInfo.getDepositIds().get(i));
-                DepositReview depositReview = restService.getDepositReview(reviewInfo.getDepositReviewIds().get(i));
+                DepositReview depositReview = restService.getDepositReview(reviewInfo.getDepositIds().get(i));
                 DepositReviewModel drm = new DepositReviewModel();
 
                 // Set DepositReview stuff

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminReviewsController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminReviewsController.java
@@ -120,13 +120,15 @@ public class AdminReviewsController {
     }
 
 
+
     // Process the completed review page
-    @PostMapping("/admin/vaults/{vaultid}/reviews/{reviewid}")
-    public String processReview(@RequestBody VaultReviewModel vaultReviewModel,
+    @RequestMapping(value = "/admin/vaults/{vaultid}/reviews/{reviewid}", method = RequestMethod.POST)
+    public String processReview(@ModelAttribute VaultReviewModel vaultReviewModel,
+                                ModelMap model,
+                                RedirectAttributes redirectAttributes,
                                 @PathVariable("vaultid") String vaultID,
                                 @PathVariable("reviewid") String reviewID,
-                                @RequestParam String action,
-                                RedirectAttributes redirectAttributes ) {
+                                @RequestParam String action) {
 
         // Note - The ModelAttributes made available here are not the same objects as those passed to the View,
         // they only contain the values entered on screen. With that in mind, fetch the original objects again and
@@ -175,7 +177,7 @@ public class AdminReviewsController {
 
         if (vaultReviewModel.getDepositReviewModels() != null) {
             for (DepositReviewModel drm : vaultReviewModel.getDepositReviewModels()) {
-                DepositReview originalDepositReview = restService.getDepositReview(drm.getDepositReviewId());
+                DepositReview originalDepositReview = restService.getDepositReview(drm.getDepositId());
                 originalDepositReview.setDeleteStatus(drm.getDeleteStatus());
                 originalDepositReview.setComment(drm.getComment());
 

--- a/datavault-webapp/src/main/webapp/WEB-INF/templates/admin/reviews/create.html
+++ b/datavault-webapp/src/main/webapp/WEB-INF/templates/admin/reviews/create.html
@@ -8,7 +8,7 @@
 
     <ol class="breadcrumb">
         <li><a th:href="@{/admin/}"><b>Administration</b></a></li>
-        <li><a th:href="@{/admin/vaults}"><b>Reviews</b></a></li>
+        <li><a th:href="@{/admin/reviews}"><b>Reviews</b></a></li>
         <li class="active"><b>Vault:</b> [[${vault.name}]]</li>
     </ol>
 

--- a/datavault-webapp/src/test/java/org/datavaultplatform/webapp/controllers/admin/AdminReviewsControllerTest.java
+++ b/datavault-webapp/src/test/java/org/datavaultplatform/webapp/controllers/admin/AdminReviewsControllerTest.java
@@ -349,7 +349,7 @@ public class AdminReviewsControllerTest {
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders.post("/admin/vaults/"+TEST_VAULT_ID_1+"/reviews/" + TEST_VAULT_REVIEW_ID)
                 .queryParam("action", "Cancel")
-                .content(toJson(mVaultReviewModel))
+                .flashAttr("VaultReviewModel", mVaultReviewModel)
                 .contentType(MediaType.APPLICATION_JSON)
                 .with(csrf());
         // Act
@@ -368,12 +368,12 @@ public class AdminReviewsControllerTest {
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders.post("/admin/vaults/"+TEST_VAULT_ID_1+"/reviews/" + TEST_VAULT_REVIEW_ID)
                 .queryParam("action", "Save")
-                .content(toJson(mVaultReviewModel))
+                .flashAttr("vaultReviewModel", mVaultReviewModel)
                 .contentType(MediaType.APPLICATION_JSON)
                 .with(csrf());
         // Act
         MvcResult mvcResult = mockMvc.perform(requestBuilder).andReturn();
-        //Assert
+        // Assert
         assertThat(mvcResult.getModelAndView().getViewName()).isEqualTo("redirect:/admin/reviews");
 
         verify(mRestService).getVaultReview(TEST_VAULT_REVIEW_ID);
@@ -396,7 +396,7 @@ public class AdminReviewsControllerTest {
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders.post("/admin/vaults/"+TEST_VAULT_ID_1+"/reviews/" + TEST_VAULT_REVIEW_ID)
                 .queryParam("action", "Submit")
-                .content(toJson(mVaultReviewModel))
+                .flashAttr("vaultReviewModel", mVaultReviewModel)
                 .contentType(MediaType.APPLICATION_JSON)
                 .with(csrf());
         // Act
@@ -421,7 +421,7 @@ public class AdminReviewsControllerTest {
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders.post("/admin/vaults/"+TEST_VAULT_ID_1+"/reviews/" + TEST_VAULT_REVIEW_ID)
                 .queryParam("action", "Submit")
-                .content(toJson(mVaultReviewModel))
+                .flashAttr("vaultReviewModel", mVaultReviewModel)
                 .contentType(MediaType.APPLICATION_JSON)
                 .with(csrf());
         // Act
@@ -451,7 +451,7 @@ public class AdminReviewsControllerTest {
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders.post("/admin/vaults/"+TEST_VAULT_ID_1+"/reviews/" + TEST_VAULT_REVIEW_ID)
                 .queryParam("action", "Submit")
-                .content(toJson(mVaultReviewModel))
+                .flashAttr("vaultReviewModel", mVaultReviewModel)
                 .contentType(MediaType.APPLICATION_JSON)
                 .with(csrf());
         // Act


### PR DESCRIPTION
1) Added default constructor to VaultReview (I don't think this fixed anything but was a suggested solution so keeping in for now) 
2) Updated VaultsController.getVault to use the correct method to get depositReviews 3) Updated AdminReviewsController.processReview signature by reverting to the old style currently deployed on live.  The new attempt let to bad media format error when clicking the form.  Some googling leads me to believe that the new sig was unhappy with nulls in the transfer object when converting to json. 
3) Updated AdminReviewsController.processReview to use the correct method to get depositReviews 
4) Updated /admin/review/create.html so that the breadcrumb to /admin/reviews is now correct
5) Updated AdminReviewsControllerTest so that the mocks now work with the reverted processReview signature