### PR TITLE
Luc070 209 further fix for footer for accessibility

### DIFF
--- a/datavault-webapp/src/main/webapp/WEB-INF/templates/layout/editvaultlayout.html
+++ b/datavault-webapp/src/main/webapp/WEB-INF/templates/layout/editvaultlayout.html
@@ -14,7 +14,7 @@
     <div id="datavault-body">
         <div layout:fragment="content">NESTED CONTENT GOES HERE</div>
     </div><!--layout-datavault--body-->
-    <div id="datavault-footer" style="z-index: -10">
+    <div id="datavault-footer">
         <div th:replace="~{layout/footer.html}"></div>
     </div><!--layout-datavault-footer-->
 </div><!--layout-datavault-container-->

--- a/datavault-webapp/src/main/webapp/resources/theme/css/createVault.css
+++ b/datavault-webapp/src/main/webapp/resources/theme/css/createVault.css
@@ -145,3 +145,8 @@
 .extra-depositor {
     margin-top: 2px;
 }
+
+#vault-creation-form .dropdown-menu,
+#pendingvault-edit-form .dropdown-menu {
+    height: 30rem !important;
+}


### PR DESCRIPTION
Changes:
Restricted the dropdown menus on the create vault pages to 30rem.
Removed the z-index: -10 from the footer.

Old:
<img width="1916" height="880" alt="Selection_008" src="https://github.com/user-attachments/assets/3a2d79dc-3bb0-425d-bef9-b68d11b27afc" />

New:
<img width="1844" height="878" alt="Selection_009" src="https://github.com/user-attachments/assets/1b05c54b-f5a4-43c7-a5ce-c4935248f5c7" />

