### PR TITLE
Cicd tmp file cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ dist/
 nbdist/
 nbactions.xml
 nb-configuration.xml
-META-INF/
 datavault-broker/src/main/webapp/WEB-INF/glassfish-web.xml
 datavault-webapp/src/main/webapp/WEB-INF/glassfish-web.xml
 ## Ignore all *.properties file in root folder, EXCEPT datavault.properties (the default)

--- a/datavault-broker/src/test/java/org/datavaultplatform/common/storage/BaseSFTPFileSystemIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/common/storage/BaseSFTPFileSystemIT.java
@@ -60,12 +60,10 @@ public abstract class BaseSFTPFileSystemIT {
   static final String TEMP_PREFIX = "dvSftpTempDir";
   static final long EXPECTED_SPACE_AVAILABLE_ON_SFTP_SERVER = 100_000;
   private static final int FREE_SPACE_FACTOR = 10;
-
-  static final Path tempLocalPath;
-
-  static {
+  
+  public static Path createTempLocalDir() {
     try {
-      tempLocalPath = Files.createTempDirectory("sftpTestFilesDir");
+      Path tempLocalPath = Files.createTempDirectory("sftpTestFilesDir");
       for (int i = 0; i < 1000; i++) {
         Path tempFile = tempLocalPath.resolve(String.format("temp-%s.txt", i));
         try (PrintWriter pw = new PrintWriter(new FileWriter(tempFile.toFile()))) {
@@ -73,6 +71,7 @@ public abstract class BaseSFTPFileSystemIT {
 
         }
       }
+      return tempLocalPath;
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/datavault-broker/src/test/java/org/datavaultplatform/common/storage/BaseSFTPFileSystemPrivatePublicKeyPairIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/common/storage/BaseSFTPFileSystemPrivatePublicKeyPairIT.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Map;
 import javax.crypto.SecretKey;
@@ -34,8 +35,7 @@ public abstract class BaseSFTPFileSystemPrivatePublicKeyPairIT extends BaseSFTPF
   static File keyStoreTempDir;
   static KeyPairInfo keyPairInfo;
 
-
-  static GenericContainer<?> initialiseContainer(String tcName) {
+  static GenericContainer<?> initialiseContainer(String tcName, Path tempFilePath) {
 
     try {
       keyStoreTempDir = Files.createTempDirectory("tmpKeyStoreDir").toFile();
@@ -51,7 +51,7 @@ public abstract class BaseSFTPFileSystemPrivatePublicKeyPairIT extends BaseSFTPF
         .withEnv(ENV_PUBLIC_KEY,
             keyPairInfo.getPublicKey()) //this causes the public key to be added to /config/.ssh/authorized_keys
         .withExposedPorts(SFTP_SERVER_PORT)
-        .withCopyFileToContainer(MountableFile.forHostPath(tempLocalPath),"/config")
+        .withCopyFileToContainer(MountableFile.forHostPath(tempFilePath),"/config")
         .waitingFor(Wait.forListeningPort());
   }
 

--- a/datavault-broker/src/test/java/org/datavaultplatform/common/storage/BaseSFTPFileSystemUsernamePasswordIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/common/storage/BaseSFTPFileSystemUsernamePasswordIT.java
@@ -1,5 +1,6 @@
 package org.datavaultplatform.common.storage;
 
+import java.nio.file.Path;
 import java.util.Map;
 import lombok.SneakyThrows;
 import org.datavaultplatform.common.PropNames;
@@ -15,7 +16,7 @@ public abstract class BaseSFTPFileSystemUsernamePasswordIT extends BaseSFTPFileS
   static final String ENV_PASSWORD_ACCESS = "PASSWORD_ACCESS";
 
 
-  static GenericContainer<?> initialiseContainer(String tcName) {
+  static GenericContainer<?> initialiseContainer(String tcName, Path tempLocalPath) {
 
     return new GenericContainer<>(DockerImage.OPEN_SSH_9pt0_IMAGE_NAME)
         .withEnv("TC_NAME", tcName)

--- a/datavault-broker/src/test/java/org/datavaultplatform/common/storage/SFTPFileSystemPrivatePublicKeyPairJSchIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/common/storage/SFTPFileSystemPrivatePublicKeyPairJSchIT.java
@@ -1,5 +1,6 @@
 package org.datavaultplatform.common.storage;
 
+import java.nio.file.Path;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.datavaultplatform.common.storage.impl.SFTPFileSystemJSch;
@@ -17,8 +18,10 @@ import org.testcontainers.junit.jupiter.Container;
 @Slf4j
 public class SFTPFileSystemPrivatePublicKeyPairJSchIT extends BaseSFTPFileSystemPrivatePublicKeyPairIT {
 
+  static final Path tempFilePath = createTempLocalDir();
+  
   @Container
-  static final GenericContainer<?> container = initialiseContainer("SftpPrivatePublicJSchDIT");
+  static final GenericContainer<?> container = initialiseContainer("SftpPrivatePublicJSchDIT", tempFilePath);
 
   @Override
   public SFTPFileSystemDriver getSftpDriver() {

--- a/datavault-broker/src/test/java/org/datavaultplatform/common/storage/SFTPFileSystemPrivatePublicKeyPairSSHDIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/common/storage/SFTPFileSystemPrivatePublicKeyPairSSHDIT.java
@@ -1,5 +1,6 @@
 package org.datavaultplatform.common.storage;
 
+import java.nio.file.Path;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.datavaultplatform.common.storage.impl.SFTPFileSystemSSHD;
@@ -17,8 +18,10 @@ import org.testcontainers.junit.jupiter.Container;
 @Slf4j
 public class SFTPFileSystemPrivatePublicKeyPairSSHDIT extends BaseSFTPFileSystemPrivatePublicKeyPairIT {
 
+  static final Path tempFilePath = createTempLocalDir();
+  
   @Container
-  static final GenericContainer<?> container = initialiseContainer("SftpPrivatePublicSSHDIT");
+  static final GenericContainer<?> container = initialiseContainer("SftpPrivatePublicSSHDIT", tempFilePath);
 
   @Override
   public SFTPFileSystemDriver getSftpDriver() {

--- a/datavault-broker/src/test/java/org/datavaultplatform/common/storage/SFTPFileSystemUsernamePasswordJSchIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/common/storage/SFTPFileSystemUsernamePasswordJSchIT.java
@@ -1,5 +1,6 @@
 package org.datavaultplatform.common.storage;
 
+import java.nio.file.Path;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.datavaultplatform.common.storage.impl.SFTPFileSystemJSch;
@@ -17,8 +18,10 @@ import org.testcontainers.junit.jupiter.Container;
 @Slf4j
 public class SFTPFileSystemUsernamePasswordJSchIT extends BaseSFTPFileSystemUsernamePasswordIT {
 
+  static final Path tempFilePath = createTempLocalDir();
+  
   @Container
-  static final GenericContainer<?> container= initialiseContainer("SftpUsernamePasswordJSchDIT");
+  static final GenericContainer<?> container= initialiseContainer("SftpUsernamePasswordJSchDIT", tempFilePath);
 
   @Override
   public SFTPFileSystemDriver getSftpDriver() {

--- a/datavault-broker/src/test/java/org/datavaultplatform/common/storage/SFTPFileSystemUsernamePasswordSSHDIT.java
+++ b/datavault-broker/src/test/java/org/datavaultplatform/common/storage/SFTPFileSystemUsernamePasswordSSHDIT.java
@@ -1,5 +1,6 @@
 package org.datavaultplatform.common.storage;
 
+import java.nio.file.Path;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.datavaultplatform.common.storage.impl.SFTPFileSystemSSHD;
@@ -17,8 +18,10 @@ import org.testcontainers.junit.jupiter.Container;
 @Slf4j
 public class SFTPFileSystemUsernamePasswordSSHDIT extends BaseSFTPFileSystemUsernamePasswordIT {
 
+  static final Path tempFilePath = createTempLocalDir();
+
   @Container
-  static final GenericContainer<?> container = initialiseContainer("SftpUsernamePasswordSSHDIT");
+  static final GenericContainer<?> container = initialiseContainer("SftpUsernamePasswordSSHDIT", tempFilePath);
 
   @Override
   public SFTPFileSystemDriver getSftpDriver() {

--- a/datavault-broker/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/datavault-broker/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.datavaultplatform.common.util.TempFileCleanerExtension

--- a/datavault-broker/src/test/resources/junit-platform.properties
+++ b/datavault-broker/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled = true

--- a/datavault-common/pom.xml
+++ b/datavault-common/pom.xml
@@ -192,6 +192,8 @@
                 <include>**/EventTest*</include>
                 <include>**/TestUtils*</include>
                 <include>**/UsesTestContainers*</include>
+                <include>**/TempFileCleaner*</include>
+                <include>**/TempFileCleanerExtension*</include>
               </includes>
             </configuration>
           </execution>

--- a/datavault-common/src/test/java/org/datavaultplatform/common/crypto/BaseTempKeyStoreTest.java
+++ b/datavault-common/src/test/java/org/datavaultplatform/common/crypto/BaseTempKeyStoreTest.java
@@ -7,8 +7,8 @@ import java.io.File;
 import javax.crypto.SecretKey;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.io.TempDir;
 
 @Slf4j
@@ -48,9 +48,20 @@ public abstract class BaseTempKeyStoreTest {
         keyForSSH);
     Encryption.saveSecretKeyToKeyStore(Encryption.getVaultDataEncryptionKeyName(),
         keyForData);
-    Assertions.assertTrue(new File(keyStorePath).exists());
 
     assertTrue(new File(keyStorePath).exists());
+  }
+  
+  @AfterEach
+  void tearDown() {
+    // JUnit @TempDir takes care of deleting the 'temp' directory
+    // but clearing the Encryption settings is good practice since they seem to be static
+    Encryption enc = new Encryption();
+    enc.setKeystoreEnable(false);
+    enc.setKeystorePath(null);
+    enc.setKeystorePassword(null);
+    enc.setVaultPrivateKeyEncryptionKeyName(null);
+    enc.setVaultDataEncryptionKeyName(null);
   }
 
 }

--- a/datavault-common/src/test/java/org/datavaultplatform/common/crypto/EncryptionTest.java
+++ b/datavault-common/src/test/java/org/datavaultplatform/common/crypto/EncryptionTest.java
@@ -29,13 +29,14 @@ import org.apache.commons.io.FileUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.util.encoders.Base64;
 import org.datavaultplatform.test.SlowTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
-public class EncryptionTest {
+class EncryptionTest {
 
     private static File bigdataResourcesDir;
     private static File testDir;
@@ -62,6 +63,17 @@ public class EncryptionTest {
             testDir.mkdir();
         } catch (SecurityException se) {
             fail(se.getMessage());
+        }
+    }
+
+    @AfterEach
+    public void tearDown() {
+        try {
+            if (testDir != null && testDir.exists()) {
+                FileUtils.deleteDirectory(testDir);
+            }
+        } catch (IOException e) {
+            log.warn("Could not delete temporary test directory: " + testDir.getAbsolutePath(), e);
         }
     }
 

--- a/datavault-common/src/test/java/org/datavaultplatform/common/util/TempFileCleaner.java
+++ b/datavault-common/src/test/java/org/datavaultplatform/common/util/TempFileCleaner.java
@@ -1,0 +1,167 @@
+package org.datavaultplatform.common.util;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.attribute.UserPrincipal;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Slf4j
+public class TempFileCleaner {
+
+    public static final File SLASH_TEMP = new File("/tmp");
+    public static final File OS_TEMP = new File(System.getProperty("java.io.tmpdir"));
+    private static final String CURRENT_USER_NAME = System.getProperty("user.name");
+
+    public static void cleanTempTestFiles(Instant startTime) {
+        cleanSlashTemp(startTime);
+        cleanOsTemp(startTime);
+    }
+
+    public static void cleanSlashTemp(Instant startTime) {
+        cleanTempFilesAndDirectories(SLASH_TEMP, startTime);
+    }
+
+    public static boolean isSlashTempSameAsOsTemp() {
+        return SLASH_TEMP.equals(OS_TEMP);
+    }
+
+    public static void cleanOsTemp(Instant startTime) {
+        if (isSlashTempSameAsOsTemp()) {
+            log.warn("OS temp directory {} is the same as /tmp, skipping", OS_TEMP);
+        } else {
+            cleanTempFilesAndDirectories(OS_TEMP, startTime);
+        }
+    }
+
+    public static void cleanTempFilesAndDirectories(File baseTemp, Instant startTime) {
+        cleanTempDirectories(baseTemp, startTime);
+        cleanTempFiles(baseTemp, startTime);
+    }
+
+    public static void cleanTempDirectories(File baseTemp, Instant startTime) {
+        List<File> dirs = findDirectories(baseTemp, startTime);
+        for (File dir : dirs) {
+            if (!Files.isWritable(dir.toPath())) {
+                log.warn("Skipping directory deletion, no write permission: {}", dir.getAbsolutePath());
+                continue;
+            }
+            try {
+                FileUtils.deleteDirectory(dir);
+                log.info("Deleted temp test directory: {}", dir.getAbsolutePath());
+            } catch (Exception ex) {
+                log.warn("Failed to delete directory: " + dir.getAbsolutePath(), ex);
+            } finally {
+                log.info("-");
+                
+            }
+        }
+    }
+
+    public static void cleanTempFiles(File baseTemp, Instant startTime) {
+        List<File> files = findFiles(baseTemp, startTime);
+        for (File file : files) {
+            if (!Files.isWritable(file.toPath())) {
+                log.warn("Skipping file deletion, no write permission: {}", file.getAbsolutePath());
+                continue;
+            }
+            try {
+                var deleted = Files.deleteIfExists(file.toPath());
+                log.info("Deleted temp test file?: {} /  {}", file.getAbsolutePath(), deleted);
+            } catch (Exception ex) {
+                log.warn("Failed to delete file: " + file.getAbsolutePath(), ex);
+            } finally {
+                log.info("-");
+                
+            }
+        }
+    }
+
+    @SneakyThrows
+    public static List<File> findDirectories(File baseTemp, Instant startTime) {
+        if (baseTemp == null || !baseTemp.exists() || !baseTemp.isDirectory()) {
+            return List.of();
+        }
+
+        List<File> dirsToDelete;
+        try (Stream<Path> stream = Files.list(baseTemp.toPath())) {
+            dirsToDelete = stream.filter(Files::isDirectory)
+                    .filter(path -> isEligibleForDeletion(path, startTime))
+                    .map(Path::toFile)
+                    .toList();
+        }
+        
+        dirsToDelete.forEach(path -> {
+            log.info("XX Deleting directory: {}", path);
+        });
+        return dirsToDelete;
+    }
+
+    @SneakyThrows
+    public static List<File> findFiles(File baseTemp, Instant startTime) {
+        if (baseTemp == null || !baseTemp.exists() || !baseTemp.isDirectory()) {
+            return List.of();
+        }
+
+        List<File> filesToDelete;
+        try (Stream<Path> stream = Files.list(baseTemp.toPath())) {
+            filesToDelete = stream.filter(Files::isRegularFile)
+                    .filter(path -> isEligibleForDeletion(path, startTime))
+                    .map(Path::toFile)
+                    .toList();
+        }
+
+        filesToDelete.forEach(path -> {
+            log.info("XX Deleting file: {}", path);
+        });
+
+        return filesToDelete;
+    }
+
+    private static boolean isEligibleForDeletion(Path path, Instant testStartTime) {
+        try {
+            // 1. Check ownership
+            UserPrincipal owner = Files.getOwner(path);
+            if (owner == null || !CURRENT_USER_NAME.equals(owner.getName())) {
+                // In Unix/Docker environments, user.name might be '?' or 'root' while owner is a numeric UID.
+                // Uncomment the line below to debug ownership mismatches in CI:
+                // log.debug("Owner mismatch: Expected {}, but got {}", CURRENT_USER_NAME, owner.getName());
+                return false;
+            }
+
+            // 2. Check creation/modification time
+            // Using BasicFileAttributes is much safer and more robust across Linux/Mac than string lookups
+            BasicFileAttributes attr = Files.readAttributes(path, BasicFileAttributes.class);
+            FileTime creationTime = attr.creationTime();
+            FileTime lastModifiedTime = attr.lastModifiedTime();
+
+            Instant created = creationTime.toInstant();
+            Instant modified = lastModifiedTime.toInstant();
+
+            // Account for filesystem timestamp truncation (e.g., macOS HFS+/APFS or older Linux filesystems)
+            // by giving a small tolerance window.
+            Instant threshold = testStartTime.minusSeconds(2);
+
+            // Only delete if the file was created OR modified AFTER the test started
+            // (We include 'modified' because some temporary files might be reused or 
+            // touched during the test rather than freshly created)
+            boolean result =  !created.isBefore(threshold) || !modified.isBefore(threshold);
+            if(result) {
+                log.info("XX {} isEligibleForDeletion? {}", path, result);
+            }
+            return result;
+        } catch (IOException e) {
+            log.debug("Could not read attributes for {}. Assuming not eligible.", path, e);
+            return false;
+        }
+    }
+}

--- a/datavault-common/src/test/java/org/datavaultplatform/common/util/TempFileCleanerExtension.java
+++ b/datavault-common/src/test/java/org/datavaultplatform/common/util/TempFileCleanerExtension.java
@@ -1,0 +1,42 @@
+package org.datavaultplatform.common.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.time.Instant;
+
+@Slf4j
+@Order(1) // High priority: ensures it runs first in beforeAll and last in afterAll
+public class TempFileCleanerExtension implements BeforeAllCallback, AfterAllCallback {
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        // Only record the time for top-level test classes
+        if (context.getRequiredTestClass().getEnclosingClass() == null) {
+            // Record the time right before the test class starts
+            // We use the specific test class context 
+            // to prevent collisions when running test classes in parallel
+            context.getStore(ExtensionContext.Namespace.create(getClass(), context.getRequiredTestClass()))
+                   .put("testStartTime", Instant.now());
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        // Only perform cleanup for top-level test classes
+        if (context.getRequiredTestClass().getEnclosingClass() == null) {
+            Instant startTime = context.getStore(ExtensionContext.Namespace.create(getClass(), context.getRequiredTestClass()))
+                                       .get("testStartTime", Instant.class);
+            if (startTime != null) {
+                log.info("XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX");
+                TempFileCleaner.cleanTempTestFiles(startTime);
+            } else {
+                // Fallback if beforeAll wasn't called for some reason (e.g., test failed before beforeAll completed)
+                TempFileCleaner.cleanTempTestFiles(Instant.EPOCH);
+            }
+        }
+    }
+}

--- a/datavault-common/src/test/java/org/datavaultplatform/common/util/TempFileCleanerExtensionTest.java
+++ b/datavault-common/src/test/java/org/datavaultplatform/common/util/TempFileCleanerExtensionTest.java
@@ -1,0 +1,38 @@
+package org.datavaultplatform.common.util;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.*;
+
+@Slf4j
+class TempFileCleanerExtensionTest {
+    
+    @Test
+    @SneakyThrows
+    void testJavaTmpDirDelete() {
+        Path tempDir = Paths.get(System.getProperty("java.io.tmpdir"));
+        Files.writeString(tempDir.resolve("testNonSlash102.txt"), "Hello world!\n");
+
+        Path path2 = tempDir.resolve("deleteNonSlash/testNonSlash103.txt");
+        Files.createDirectories(path2.getParent());
+        Files.writeString(path2, "Hello world!\n");
+    }
+
+    @Test
+    @SneakyThrows
+    void testSlashTmpDirDelete() {
+        Path path = Paths.get("/tmp/deleteSlash/test100.txt");
+
+        // Create parent directories if they don't exist
+        Files.createDirectories(path.getParent());
+
+        // Write text to the file
+        Files.writeString(path, "Hello world!\n");
+
+        Files.writeString(Paths.get("/tmp/testSlash101.txt"), "Hello world!\n");
+    }
+    
+    
+}

--- a/datavault-common/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/datavault-common/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.datavaultplatform.common.util.TempFileCleanerExtension

--- a/datavault-common/src/test/resources/junit-platform.properties
+++ b/datavault-common/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled = true

--- a/datavault-webapp/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/datavault-webapp/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.datavaultplatform.common.util.TempFileCleanerExtension

--- a/datavault-webapp/src/test/resources/junit-platform.properties
+++ b/datavault-webapp/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled = true

--- a/datavault-worker/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/datavault-worker/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.datavaultplatform.common.util.TempFileCleanerExtension

--- a/datavault-worker/src/test/resources/junit-platform.properties
+++ b/datavault-worker/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled = true

--- a/dv5/test-scripts/runWorkerIntegrationTestsOnly.sh
+++ b/dv5/test-scripts/runWorkerIntegrationTestsOnly.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+java -version
+
+export PROJECT_ROOT=$(cd ../../;pwd)
+cd $PROJECT_ROOT
+
+./mvnw clean integration-test -Dskip.unit.tests -pl datavault-worker

--- a/dv5/test-scripts/runWorkerUnitTestsOnly.sh
+++ b/dv5/test-scripts/runWorkerUnitTestsOnly.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+java -version
+
+export PROJECT_ROOT=$(cd ../../;pwd)
+cd $PROJECT_ROOT
+
+./mvnw clean test -pl datavault-worker

--- a/pom.xml
+++ b/pom.xml
@@ -551,6 +551,7 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${failsafe.plugin.version}</version>
           <configuration>
+            <argLine>-Duser.timezone=Europe/London</argLine>
             <skipITs>${skip.integration.tests}</skipITs>
             <systemPropertyVariables>
               <junit.jupiter.execution.timeout.default>300 s</junit.jupiter.execution.timeout.default>
@@ -563,6 +564,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${surefire.plugin.version}</version>
           <configuration>
+            <argLine>-Duser.timezone=Europe/London</argLine>
             <skipTests>${skip.unit.tests}</skipTests>
             <excludedGroups>slow,org.datavaultplatform.test.TSMTest</excludedGroups>
             <systemPropertyVariables>


### PR DESCRIPTION
Added a junit extension that finds tmp files and directories created/modified after a junit test class has finished and deletes them.
Work with Both MacOs and Linux.
On Linux - **/tmp** and the value of the java system property **java.io.tmpdir** are the same on macos they are different.
On MacOs - the **java.io.tmpdir** system property points to $TMPDIR - which would be something like "**/var/folders/l6/_tg4808d31xcdk_pv81btkz40000gn/T**".