### PR TITLE
remove admin-only security restrictions on /vaults/autocompleteuun and /vaults/isuun

### DIFF
--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/VaultsController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/VaultsController.java
@@ -534,7 +534,7 @@ public class VaultsController {
         return "redirect:" + vaultUrl;
     }
 
-    @PreAuthorize("hasRole('IS_ADMIN')")
+    //@PreAuthorize("hasRole('IS_ADMIN')")
     @RequestMapping(value = "/vaults/autocompleteuun/{term}", method = RequestMethod.GET)
     @ResponseBody
     public String autocompleteUUN(@PathVariable("term") String term) {
@@ -543,7 +543,7 @@ public class VaultsController {
         return gson.toJson(result);
     }
 
-    @PreAuthorize("hasRole('IS_ADMIN')")
+    //@PreAuthorize("hasRole('IS_ADMIN')")
     @RequestMapping(value = "/vaults/isuun/{uun}", method = RequestMethod.GET)
     @ResponseBody
     public String isUUN(@PathVariable("uun") String uun) {

--- a/datavault-webapp/src/test/java/org/datavaultplatform/webapp/controllers/VaultsControllerMvcTest.java
+++ b/datavault-webapp/src/test/java/org/datavaultplatform/webapp/controllers/VaultsControllerMvcTest.java
@@ -9,10 +9,7 @@ import org.datavaultplatform.webapp.services.RestService;
 import org.datavaultplatform.webapp.services.UserLookupService;
 import org.datavaultplatform.webapp.test.AddTestProperties;
 import org.datavaultplatform.webapp.test.ProfileDatabase;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -199,6 +196,7 @@ class VaultsControllerMvcTest {
     @Order(7)
     @SneakyThrows
     @WithMockUser(username = "vanilla-user", roles = {"USER"})
+    @Disabled("This test is disabled as we think how to secure uun search")
     void testIsUUN_ForbiddenAsVanillaUser() {
         mockMvc.perform(get("/vaults/isuun/v1dhay3")).andExpect(status().isForbidden());
         verifyNoMoreInteractions(restService, userLookupService);
@@ -225,6 +223,7 @@ class VaultsControllerMvcTest {
     @Order(9)
     @SneakyThrows
     @WithMockUser(username = "vanilla-user", roles = {"USER"})
+    @Disabled("This test is disabled as we think how to secure uun search")
     void testAutocompleteUUN_ForbiddenAsVanillaUser() {
         mockMvc.perform(get("/vaults/autocompleteuun/blah")).andExpect(status().isForbidden());
         verifyNoMoreInteractions(restService, userLookupService);


### PR DESCRIPTION
removed admin-only security restrictions on /vaults/autocompleteuun/{term} and /vaults/isuun/{uun} - they are too restrictive