### PR TITLE
LUC070-264-bad-dsmc-params-remove-problematic-dsmc-options

### DIFF
--- a/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/storage/impl/TivoliStorageManager.java
@@ -415,8 +415,8 @@ public class TivoliStorageManager extends Device implements ArchiveStore {
 		List<String> result = new ArrayList<>(commands);
 		// these "dsmc" options are best practice when
 		// using 'dsmc' for non-interactive session where simple text output is best
-		result.add("-displaymode=list");
-		result.add("-noprompt");
+		//result.add("-displaymode=list");
+		//result.add("-noprompt");
 		return result;
 	}
 }

--- a/datavault-common/src/test/java/org/datavaultplatform/common/storage/impl/TivoliStorageManagerTest.java
+++ b/datavault-common/src/test/java/org/datavaultplatform/common/storage/impl/TivoliStorageManagerTest.java
@@ -604,7 +604,7 @@ class TivoliStorageManagerTest {
         @Test
         void testCommandsWithDsmc() {
             String[] result = TivoliStorageManager.cleanTsmCommand(WITH_DSMC);
-            assertThat(result).containsExactly("script", "-q", "/dev/null", "dsmc", "opt1", "opt2", "-displaymode=list", "-noprompt");
+            assertThat(result).containsExactly("script", "-q", "/dev/null", "dsmc", "opt1", "opt2");
         }
 
         @Test


### PR DESCRIPTION
removed use of displaymode and noprompt options which were meant to improve use of dcmc on the workers but in fact caused problems.